### PR TITLE
clang compilation, initialization cleanup, unlimited instances, and more...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Cflat.cpp
+++ b/Cflat.cpp
@@ -74,7 +74,7 @@ namespace Cflat
    //
    //  AST Types
    //
-   enum class ExpressionType
+   enum class ExpressionType : uint8_t
    {
       Value,
       NullPointer,
@@ -524,7 +524,7 @@ namespace Cflat
    };
 
 
-   enum class StatementType
+   enum class StatementType : uint8_t
    {
       Expression,
       Block,

--- a/Cflat.cpp
+++ b/Cflat.cpp
@@ -30,6 +30,7 @@
 
 #include "Cflat.h"
 
+#include <cmath>
 
 //
 //  Internal definitions
@@ -7565,7 +7566,7 @@ void Environment::applyBinaryOperator(ExecutionContext& pContext, const Value& p
          }
          else
          {
-            if(fabs(rightValueAsDecimal) > 0.000000001)
+            if(std::fabs(rightValueAsDecimal) > 0.000000001)
             {
                setValueAsDecimal(leftValueAsDecimal / rightValueAsDecimal, pOutValue);
             }

--- a/Cflat.cpp
+++ b/Cflat.cpp
@@ -1159,17 +1159,17 @@ bool TypeUsage::isPointer() const
 
 bool TypeUsage::isConst() const
 {
-   return CflatHasFlag(mFlags, TypeUsageFlags::Const);
+   return has_flag(mFlags, TypeUsageFlags::Const);
 }
 
 bool TypeUsage::isReference() const
 {
-   return CflatHasFlag(mFlags, TypeUsageFlags::Reference);
+   return has_flag(mFlags, TypeUsageFlags::Reference);
 }
 
 bool TypeUsage::isArray() const
 {
-   return CflatHasFlag(mFlags, TypeUsageFlags::Array);
+   return has_flag(mFlags, TypeUsageFlags::Array);
 }
 
 bool TypeUsage::compatibleWith(const TypeUsage& pOther) const
@@ -2972,7 +2972,7 @@ TypeUsage Environment::parseTypeUsage(ParsingContext& pContext, size_t pTokenLas
    if(tokens[tokenIndex].mType == TokenType::Keyword &&
       strncmp(tokens[tokenIndex].mStart, "const", 5u) == 0)
    {
-      CflatSetFlag(typeUsage.mFlags, TypeUsageFlags::Const);
+      set_flag(typeUsage.mFlags, TypeUsageFlags::Const);
       tokenIndex++;
    }
 
@@ -3042,7 +3042,7 @@ TypeUsage Environment::parseTypeUsage(ParsingContext& pContext, size_t pTokenLas
    {
       if(tokenIndex < (tokens.size() - 1u) && *tokens[tokenIndex + 1u].mStart == '&')
       {
-         CflatSetFlag(typeUsage.mFlags, TypeUsageFlags::Reference);
+         set_flag(typeUsage.mFlags, TypeUsageFlags::Reference);
          tokenIndex++;
       }
 
@@ -5255,7 +5255,7 @@ StatementVariableDeclaration* Environment::parseStatementVariableDeclaration(Par
          }
 
          CflatAssert(arraySize > 0u);
-         CflatSetFlag(pTypeUsage.mFlags, TypeUsageFlags::Array);
+         set_flag(pTypeUsage.mFlags, TypeUsageFlags::Array);
          pTypeUsage.mArraySize = arraySize;
       }
       // variable/object
@@ -6215,7 +6215,7 @@ TypeUsage Environment::getTypeUsage(Context& pContext, Expression* pExpression)
 
             if(typeUsage.isArray())
             {
-               CflatResetFlag(typeUsage.mFlags, TypeUsageFlags::Array);
+               reset_flag(typeUsage.mFlags, TypeUsageFlags::Array);
                typeUsage.mArraySize = 1u;
             }
             else
@@ -6230,7 +6230,7 @@ TypeUsage Environment::getTypeUsage(Context& pContext, Expression* pExpression)
             typeUsage = expression->mOperator[0] == '!'
                ? mTypeUsageBool
                : getTypeUsage(pContext, expression->mExpression);
-            CflatResetFlag(typeUsage.mFlags, TypeUsageFlags::Reference);
+            reset_flag(typeUsage.mFlags, TypeUsageFlags::Reference);
          }
          break;
       case ExpressionType::BinaryOperation:
@@ -6272,7 +6272,7 @@ TypeUsage Environment::getTypeUsage(Context& pContext, Expression* pExpression)
                      typeUsage = leftTypeUsage;
                   }
 
-                  CflatResetFlag(typeUsage.mFlags, TypeUsageFlags::Reference);
+                  reset_flag(typeUsage.mFlags, TypeUsageFlags::Reference);
                }
             }
          }
@@ -6337,7 +6337,7 @@ TypeUsage Environment::getTypeUsage(Context& pContext, Expression* pExpression)
             ExpressionArrayInitialization* expression =
                static_cast<ExpressionArrayInitialization*>(pExpression);
             typeUsage.mType = expression->mElementType;
-            CflatSetFlag(typeUsage.mFlags, TypeUsageFlags::Array);
+            set_flag(typeUsage.mFlags, TypeUsageFlags::Array);
             typeUsage.mArraySize = (uint16_t)expression->mValues.size();
          }
          break;
@@ -6688,7 +6688,7 @@ void Environment::evaluateExpression(ExecutionContext& pContext, Expression* pEx
 
          if(arrayElementTypeUsage.isArray())
          {
-            CflatResetFlag(arrayElementTypeUsage.mFlags, TypeUsageFlags::Array);
+            reset_flag(arrayElementTypeUsage.mFlags, TypeUsageFlags::Array);
             arrayElementTypeUsage.mArraySize = 1u;
          }
          else
@@ -6945,20 +6945,20 @@ void Environment::evaluateExpression(ExecutionContext& pContext, Expression* pEx
             preparedArgumentValues);
 
          const bool functionReturnValueIsConst =
-            CflatHasFlag(function->mReturnTypeUsage.mFlags, TypeUsageFlags::Const);
+            has_flag(function->mReturnTypeUsage.mFlags, TypeUsageFlags::Const);
          const bool outValueIsConst =
-            CflatHasFlag(pOutValue->mTypeUsage.mFlags, TypeUsageFlags::Const);
+            has_flag(pOutValue->mTypeUsage.mFlags, TypeUsageFlags::Const);
 
          if(outValueIsConst && !functionReturnValueIsConst)
          {
-            CflatResetFlag(pOutValue->mTypeUsage.mFlags, TypeUsageFlags::Const);
+            reset_flag(pOutValue->mTypeUsage.mFlags, TypeUsageFlags::Const);
          }
 
          function->execute(preparedArgumentValues, pOutValue);
 
          if(outValueIsConst && !functionReturnValueIsConst)
          {
-            CflatSetFlag(pOutValue->mTypeUsage.mFlags, TypeUsageFlags::Const);
+            set_flag(pOutValue->mTypeUsage.mFlags, TypeUsageFlags::Const);
          }
 
          while(!preparedArgumentValues.empty())
@@ -7040,7 +7040,7 @@ void Environment::evaluateExpression(ExecutionContext& pContext, Expression* pEx
 
          TypeUsage arrayTypeUsage;
          arrayTypeUsage.mType = expression->mElementType;
-         CflatSetFlag(arrayTypeUsage.mFlags, TypeUsageFlags::Array);
+         set_flag(arrayTypeUsage.mFlags, TypeUsageFlags::Array);
          arrayTypeUsage.mArraySize = (uint16_t)expression->mValues.size();
 
          assertValueInitialization(pContext, arrayTypeUsage, pOutValue);
@@ -7230,7 +7230,7 @@ void Environment::prepareArgumentsForFunctionCall(ExecutionContext& pContext,
       if(pParameters[i].isReference())
       {
          pPreparedValues[i] = pOriginalValues[i];
-         CflatSetFlag(pPreparedValues[i].mTypeUsage.mFlags, TypeUsageFlags::Reference);
+         set_flag(pPreparedValues[i].mTypeUsage.mFlags, TypeUsageFlags::Reference);
       }
       // pass by value
       else

--- a/Cflat.cpp
+++ b/Cflat.cpp
@@ -59,7 +59,7 @@ namespace Cflat
    }
 
    template<typename T>
-   void toArgsVector(const Vector<T> pSTLVector, CflatArgsVector(T)& pArgsVector)
+   void toArgsVector(const Vector<T> pSTLVector, ArgsVector<T>& pArgsVector)
    {
       const size_t elementsCount = pSTLVector.size();
       pArgsVector.resize(elementsCount);
@@ -1140,7 +1140,7 @@ bool Type::compatibleWith(const Type& pOther) const
 //
 //  TypeUsage
 //
-const CflatArgsVector(TypeUsage) TypeUsage::kEmptyList;
+const ArgsVector<TypeUsage> TypeUsage::kEmptyList;
 
 size_t TypeUsage::getSize() const
 {
@@ -1220,7 +1220,7 @@ Member::Member(const Identifier& pIdentifier)
 //
 //  Value
 //
-const CflatArgsVector(Value) Value::kEmptyList;
+const ArgsVector<Value> Value::kEmptyList;
 
 Value::Value()
    : mValueBufferType(ValueBufferType::Uninitialized)
@@ -1423,7 +1423,7 @@ Type* TypesHolder::getType(const Identifier& pIdentifier)
    return it != mTypes.end() ? it->second : nullptr;
 }
 
-Type* TypesHolder::getType(const Identifier& pIdentifier, const CflatArgsVector(TypeUsage)& pTemplateTypes)
+Type* TypesHolder::getType(const Identifier& pIdentifier, const ArgsVector<TypeUsage>& pTemplateTypes)
 {
    Hash hash = pIdentifier.mHash;
 
@@ -1475,7 +1475,7 @@ Function* FunctionsHolder::getFunction(const Identifier& pIdentifier)
 }
 
 Function* FunctionsHolder::getFunction(const Identifier& pIdentifier,
-   const CflatArgsVector(TypeUsage)& pParameterTypes, const CflatArgsVector(TypeUsage)& pTemplateTypes)
+   const ArgsVector<TypeUsage>& pParameterTypes, const ArgsVector<TypeUsage>& pTemplateTypes)
 {
    Function* function = nullptr;
    Vector<Function*>* functions = getFunctions(pIdentifier);
@@ -1550,9 +1550,9 @@ Function* FunctionsHolder::getFunction(const Identifier& pIdentifier,
 }
 
 Function* FunctionsHolder::getFunction(const Identifier& pIdentifier,
-   const CflatArgsVector(Value)& pArguments, const CflatArgsVector(TypeUsage)& pTemplateTypes)
+   const ArgsVector<Value>& pArguments, const ArgsVector<TypeUsage>& pTemplateTypes)
 {
-   CflatArgsVector(TypeUsage) typeUsages;
+   ArgsVector<TypeUsage> typeUsages;
 
    for(size_t i = 0u; i < pArguments.size(); i++)
    {
@@ -1681,7 +1681,7 @@ void InstancesHolder::releaseInstances(uint32_t pScopeLevel, bool pExecuteDestru
                   thisPtrValue.initExternal(thisPtrTypeUsage);
                   thisPtrValue.set(&instance.mValue.mValueBuffer);
 
-                  CflatArgsVector(Value) args;
+                  ArgsVector<Value> args;
                   dtor.execute(thisPtrValue, args, nullptr);
 
                   break;
@@ -1782,7 +1782,7 @@ Type* Struct::getType(const Identifier& pIdentifier)
    return mTypesHolder.getType(pIdentifier);
 }
 
-Type* Struct::getType(const Identifier& pIdentifier, const CflatArgsVector(TypeUsage)& pTemplateTypes)
+Type* Struct::getType(const Identifier& pIdentifier, const ArgsVector<TypeUsage>& pTemplateTypes)
 {
    return mTypesHolder.getType(pIdentifier, pTemplateTypes);
 }
@@ -1808,15 +1808,15 @@ Function* Struct::getStaticMethod(const Identifier& pIdentifier)
 }
 
 Function* Struct::getStaticMethod(const Identifier& pIdentifier,
-   const CflatArgsVector(TypeUsage)& pParameterTypes,
-   const CflatArgsVector(TypeUsage)& pTemplateTypes)
+   const ArgsVector<TypeUsage>& pParameterTypes,
+   const ArgsVector<TypeUsage>& pTemplateTypes)
 {
    return mFunctionsHolder.getFunction(pIdentifier, pParameterTypes, pTemplateTypes);
 }
 
 Function* Struct::getStaticMethod(const Identifier& pIdentifier,
-   const CflatArgsVector(Value)& pArguments,
-   const CflatArgsVector(TypeUsage)& pTemplateTypes)
+   const ArgsVector<Value>& pArguments,
+   const ArgsVector<TypeUsage>& pTemplateTypes)
 {
    return mFunctionsHolder.getFunction(pIdentifier, pArguments, pTemplateTypes);
 }
@@ -2310,7 +2310,7 @@ Type* Namespace::getType(const Identifier& pIdentifier, bool pExtendSearchToPare
 }
 
 Type* Namespace::getType(const Identifier& pIdentifier,
-   const CflatArgsVector(TypeUsage)& pTemplateTypes, bool pExtendSearchToParent)
+   const ArgsVector<TypeUsage>& pTemplateTypes, bool pExtendSearchToParent)
 {
    const char* lastSeparator = pIdentifier.findLastSeparator();
 
@@ -2428,8 +2428,8 @@ Function* Namespace::getFunction(const Identifier& pIdentifier, bool pExtendSear
 }
 
 Function* Namespace::getFunction(const Identifier& pIdentifier,
-   const CflatArgsVector(TypeUsage)& pParameterTypes,
-   const CflatArgsVector(TypeUsage)& pTemplateTypes,
+   const ArgsVector<TypeUsage>& pParameterTypes,
+   const ArgsVector<TypeUsage>& pTemplateTypes,
    bool pExtendSearchToParent)
 {
    const char* lastSeparator = pIdentifier.findLastSeparator();
@@ -2471,8 +2471,8 @@ Function* Namespace::getFunction(const Identifier& pIdentifier,
 }
 
 Function* Namespace::getFunction(const Identifier& pIdentifier,
-   const CflatArgsVector(Value)& pArguments,
-   const CflatArgsVector(TypeUsage)& pTemplateTypes,
+   const ArgsVector<Value>& pArguments,
+   const ArgsVector<TypeUsage>& pTemplateTypes,
    bool pExtendSearchToParent)
 {
    const char* lastSeparator = pIdentifier.findLastSeparator();
@@ -2989,7 +2989,7 @@ TypeUsage Environment::parseTypeUsage(ParsingContext& pContext, size_t pTokenLas
 
    strcpy(baseTypeName, pContext.mStringBuffer.c_str());
    const Identifier baseTypeIdentifier(baseTypeName);
-   CflatArgsVector(TypeUsage) templateTypes;
+   ArgsVector<TypeUsage> templateTypes;
 
    if(tokenIndex < (tokens.size() - 1u) && tokens[tokenIndex + 1u].mStart[0] == '<')
    {
@@ -3660,7 +3660,7 @@ Expression* Environment::parseExpressionMultipleTokens(ParsingContext& pContext,
 
                if(rightTypeUsage.mType)
                {
-                  CflatArgsVector(TypeUsage) args;
+                  ArgsVector<TypeUsage> args;
                   args.push_back(rightTypeUsage);
 
                   pContext.mStringBuffer.assign("operator");
@@ -4337,7 +4337,7 @@ Expression* Environment::parseExpressionFunctionCall(ParsingContext& pContext,
       return nullptr;
    }
 
-   CflatArgsVector(TypeUsage) argumentTypes;
+   ArgsVector<TypeUsage> argumentTypes;
 
    for(size_t i = 0u; i < expression->mArguments.size(); i++)
    {
@@ -4345,7 +4345,7 @@ Expression* Environment::parseExpressionFunctionCall(ParsingContext& pContext,
       argumentTypes.push_back(typeUsage);
    }
 
-   CflatArgsVector(TypeUsage) templateTypes;
+   ArgsVector<TypeUsage> templateTypes;
    toArgsVector(expression->mTemplateTypes, templateTypes);
 
    expression->mFunction = findFunction(pContext, pFunctionIdentifier, argumentTypes, templateTypes);
@@ -4413,7 +4413,7 @@ Expression* Environment::parseExpressionMethodCall(ParsingContext& pContext, Exp
    CflatAssert(methodOwnerType);
    CflatAssert(methodOwnerType->mCategory == TypeCategory::StructOrClass);
 
-   CflatArgsVector(TypeUsage) argumentTypes;
+   ArgsVector<TypeUsage> argumentTypes;
 
    for(size_t i = 0u; i < expression->mArguments.size(); i++)
    {
@@ -4421,7 +4421,7 @@ Expression* Environment::parseExpressionMethodCall(ParsingContext& pContext, Exp
       argumentTypes.push_back(typeUsage);
    }
 
-   CflatArgsVector(TypeUsage) templateTypes;
+   ArgsVector<TypeUsage> templateTypes;
    toArgsVector(expression->mTemplateTypes, templateTypes);
 
    const Identifier& methodId = memberAccess->mMemberIdentifier;
@@ -4448,7 +4448,7 @@ Expression* Environment::parseExpressionObjectConstruction(ParsingContext& pCont
       return nullptr;
    }
 
-   CflatArgsVector(TypeUsage) argumentTypes;
+   ArgsVector<TypeUsage> argumentTypes;
 
    for(size_t i = 0u; i < expression->mArguments.size(); i++)
    {
@@ -5437,7 +5437,7 @@ StatementFunctionDeclaration* Environment::parseStatementFunctionDeclaration(Par
       pContext.mScopeLevel--;
    }
 
-   CflatArgsVector(TypeUsage) parameterTypes;
+   ArgsVector<TypeUsage> parameterTypes;
    toArgsVector(statement->mParameterTypes, parameterTypes);
 
    Function* function =
@@ -5985,7 +5985,7 @@ StatementForRangeBased* Environment::parseStatementForRangeBased(ParsingContext&
 
                if(indirectionOperatorMethod)
                {
-                  CflatArgsVector(TypeUsage) nonEqualOperatorParameterTypes;
+                  ArgsVector<TypeUsage> nonEqualOperatorParameterTypes;
                   nonEqualOperatorParameterTypes.push_back(iteratorTypeUsage);
 
                   validStatement = 
@@ -6358,7 +6358,7 @@ TypeUsage Environment::getTypeUsage(Context& pContext, Expression* pExpression)
 }
 
 Type* Environment::findType(const Context& pContext, const Identifier& pIdentifier,
-   const CflatArgsVector(TypeUsage)& pTemplateTypes)
+   const ArgsVector<TypeUsage>& pTemplateTypes)
 {
    Type* type = nullptr;
 
@@ -6398,8 +6398,8 @@ Type* Environment::findType(const Context& pContext, const Identifier& pIdentifi
 }
 
 Function* Environment::findFunction(const Context& pContext, const Identifier& pIdentifier,
-   const CflatArgsVector(TypeUsage)& pParameterTypes,
-   const CflatArgsVector(TypeUsage)& pTemplateTypes)
+   const ArgsVector<TypeUsage>& pParameterTypes,
+   const ArgsVector<TypeUsage>& pTemplateTypes)
 {
    Namespace* ns = pContext.mNamespaceStack.back();
    Function* function = ns->getFunction(pIdentifier, pParameterTypes, pTemplateTypes, true);
@@ -6423,10 +6423,10 @@ Function* Environment::findFunction(const Context& pContext, const Identifier& p
 }
 
 Function* Environment::findFunction(const Context& pContext, const Identifier& pIdentifier,
-   const CflatArgsVector(Value)& pArguments,
-   const CflatArgsVector(TypeUsage)& pTemplateTypes)
+   const ArgsVector<Value>& pArguments,
+   const ArgsVector<TypeUsage>& pTemplateTypes)
 {
-   CflatArgsVector(TypeUsage) typeUsages;
+   ArgsVector<TypeUsage> typeUsages;
 
    for(size_t i = 0u; i < pArguments.size(); i++)
    {
@@ -6937,10 +6937,10 @@ void Environment::evaluateExpression(ExecutionContext& pContext, Expression* pEx
 
          assertValueInitialization(pContext, function->mReturnTypeUsage, pOutValue);
 
-         CflatArgsVector(Value) argumentValues;
+         ArgsVector<Value> argumentValues;
          getArgumentValues(pContext, expression->mArguments, argumentValues);
 
-         CflatArgsVector(Value) preparedArgumentValues;
+         ArgsVector<Value> preparedArgumentValues;
          prepareArgumentsForFunctionCall(pContext, function->mParameters, argumentValues,
             preparedArgumentValues);
 
@@ -6995,10 +6995,10 @@ void Environment::evaluateExpression(ExecutionContext& pContext, Expression* pEx
          if(!mErrorMessage.empty())
             break;
 
-         CflatArgsVector(Value) argumentValues;
+         ArgsVector<Value> argumentValues;
          getArgumentValues(pContext, expression->mArguments, argumentValues);
 
-         CflatArgsVector(Value) preparedArgumentValues;
+         ArgsVector<Value> preparedArgumentValues;
          prepareArgumentsForFunctionCall(pContext, method->mParameters, argumentValues,
             preparedArgumentValues);
 
@@ -7069,7 +7069,7 @@ void Environment::evaluateExpression(ExecutionContext& pContext, Expression* pEx
          typeUsage.mType = expression->mObjectType;
          assertValueInitialization(pContext, typeUsage, pOutValue);
 
-         CflatArgsVector(Value) argumentValues;
+         ArgsVector<Value> argumentValues;
          getArgumentValues(pContext, expression->mArguments, argumentValues);
 
          Value thisPtr;
@@ -7206,7 +7206,7 @@ void Environment::getAddressOfValue(ExecutionContext& pContext, const Value& pIn
 }
 
 void Environment::getArgumentValues(ExecutionContext& pContext,
-   const Vector<Expression*>& pExpressions, CflatArgsVector(Value)& pValues)
+   const Vector<Expression*>& pExpressions, ArgsVector<Value>& pValues)
 {
    pValues.resize(pExpressions.size());
 
@@ -7218,8 +7218,8 @@ void Environment::getArgumentValues(ExecutionContext& pContext,
 }
 
 void Environment::prepareArgumentsForFunctionCall(ExecutionContext& pContext,
-   const Vector<TypeUsage>& pParameters, const CflatArgsVector(Value)& pOriginalValues,
-   CflatArgsVector(Value)& pPreparedValues)
+   const Vector<TypeUsage>& pParameters, const ArgsVector<Value>& pOriginalValues,
+   ArgsVector<Value>& pPreparedValues)
 {
    CflatAssert(pParameters.size() == pOriginalValues.size());
    pPreparedValues.resize(pParameters.size());
@@ -7305,7 +7305,7 @@ void Environment::applyUnaryOperator(ExecutionContext& pContext, const Value& pO
       pContext.mStringBuffer.assign("operator");
       pContext.mStringBuffer.append(pOperator);
 
-      CflatArgsVector(Value) args;
+      ArgsVector<Value> args;
 
       const Identifier operatorIdentifier(pContext.mStringBuffer.c_str());
       Method* operatorMethod = findMethod(type, operatorIdentifier);
@@ -7538,7 +7538,7 @@ void Environment::applyBinaryOperator(ExecutionContext& pContext, const Value& p
       pContext.mStringBuffer.assign("operator");
       pContext.mStringBuffer.append(pOperator);
 
-      CflatArgsVector(Value) args;
+      ArgsVector<Value> args;
       args.push_back(pRight);
 
       const Identifier operatorIdentifier(pContext.mStringBuffer.c_str());
@@ -7727,7 +7727,7 @@ void Environment::assignValue(ExecutionContext& pContext, const Value& pSource, 
       {
          Struct* type = static_cast<Struct*>(pTarget->mTypeUsage.mType);
 
-         CflatArgsVector(Value) args;
+         ArgsVector<Value> args;
          args.push_back(pSource);
 
          const Identifier operatorIdentifier("operator=");
@@ -7953,13 +7953,13 @@ Method* Environment::getDestructor(Type* pType)
    return destructor;
 }
 
-Method* Environment::findConstructor(Type* pType, const CflatArgsVector(TypeUsage)& pParameterTypes)
+Method* Environment::findConstructor(Type* pType, const ArgsVector<TypeUsage>& pParameterTypes)
 {
    const Identifier emptyId;
    return findMethod(pType, emptyId, pParameterTypes);
 }
 
-Method* Environment::findConstructor(Type* pType, const CflatArgsVector(Value)& pArguments)
+Method* Environment::findConstructor(Type* pType, const ArgsVector<Value>& pArguments)
 {
    const Identifier emptyId;
    return findMethod(pType, emptyId, pArguments);
@@ -7985,7 +7985,7 @@ Method* Environment::findMethod(Type* pType, const Identifier& pIdentifier)
 }
 
 Method* Environment::findMethod(Type* pType, const Identifier& pIdentifier,
-   const CflatArgsVector(TypeUsage)& pParameterTypes, const CflatArgsVector(TypeUsage)& pTemplateTypes)
+   const ArgsVector<TypeUsage>& pParameterTypes, const ArgsVector<TypeUsage>& pTemplateTypes)
 {
    CflatAssert(pType->mCategory == TypeCategory::StructOrClass);
 
@@ -8057,9 +8057,9 @@ Method* Environment::findMethod(Type* pType, const Identifier& pIdentifier,
 }
 
 Method* Environment::findMethod(Type* pType, const Identifier& pIdentifier,
-   const CflatArgsVector(Value)& pArguments, const CflatArgsVector(TypeUsage)& pTemplateTypes)
+   const ArgsVector<Value>& pArguments, const ArgsVector<TypeUsage>& pTemplateTypes)
 {
-   CflatArgsVector(TypeUsage) typeUsages;
+   ArgsVector<TypeUsage> typeUsages;
 
    for(size_t i = 0u; i < pArguments.size(); i++)
    {
@@ -8069,7 +8069,7 @@ Method* Environment::findMethod(Type* pType, const Identifier& pIdentifier,
    return findMethod(pType, pIdentifier, typeUsages);
 }
 
-void Environment::initArgumentsForFunctionCall(Function* pFunction, CflatArgsVector(Value)& pArgs)
+void Environment::initArgumentsForFunctionCall(Function* pFunction, ArgsVector<Value>& pArgs)
 {
    pArgs.resize(pFunction->mParameters.size());
 
@@ -8210,7 +8210,7 @@ void Environment::execute(ExecutionContext& pContext, Statement* pStatement)
                thisPtr.mValueInitializationHint = ValueInitializationHint::Stack;
                getAddressOfValue(pContext, instance->mValue, &thisPtr);
 
-               CflatArgsVector(Value) args;
+               ArgsVector<Value> args;
                defaultCtor->execute(thisPtr, args, nullptr);
             }
          }
@@ -8229,7 +8229,7 @@ void Environment::execute(ExecutionContext& pContext, Statement* pStatement)
       {
          StatementFunctionDeclaration* statement = static_cast<StatementFunctionDeclaration*>(pStatement);
 
-         CflatArgsVector(TypeUsage) parameterTypes;
+         ArgsVector<TypeUsage> parameterTypes;
          toArgsVector(statement->mParameterTypes, parameterTypes);
 
          Namespace* functionNS = pContext.mNamespaceStack.back();
@@ -8246,7 +8246,7 @@ void Environment::execute(ExecutionContext& pContext, Statement* pStatement)
             function->mUsingDirectives = pContext.mUsingDirectives;
             function->execute =
                [this, &pContext, function, functionNS, statement]
-               (const CflatArgsVector(Value)& pArguments, Value* pOutReturnValue)
+               (const ArgsVector<Value>& pArguments, Value* pOutReturnValue)
             {
                CflatAssert(function->mParameters.size() == pArguments.size());
 
@@ -8643,7 +8643,7 @@ Type* Environment::getType(const Identifier& pIdentifier)
    return mGlobalNamespace.getType(pIdentifier);
 }
 
-Type* Environment::getType(const Identifier& pIdentifier, const CflatArgsVector(TypeUsage)& pTemplateTypes)
+Type* Environment::getType(const Identifier& pIdentifier, const ArgsVector<TypeUsage>& pTemplateTypes)
 {
    return mGlobalNamespace.getType(pIdentifier, pTemplateTypes);
 }
@@ -8674,13 +8674,13 @@ Function* Environment::getFunction(const Identifier& pIdentifier)
 }
 
 Function* Environment::getFunction(const Identifier& pIdentifier,
-   const CflatArgsVector(TypeUsage)& pParameterTypes)
+   const ArgsVector<TypeUsage>& pParameterTypes)
 {
    return mGlobalNamespace.getFunction(pIdentifier, pParameterTypes);
 }
 
 Function* Environment::getFunction(const Identifier& pIdentifier,
-   const CflatArgsVector(Value)& pArguments)
+   const ArgsVector<Value>& pArguments)
 {
    return mGlobalNamespace.getFunction(pIdentifier, pArguments);
 }
@@ -8709,7 +8709,7 @@ void Environment::voidFunctionCall(Function* pFunction)
 
    Value returnValue;
 
-   CflatArgsVector(Value) args;
+   ArgsVector<Value> args;
    pFunction->execute(args, &returnValue);
 }
 

--- a/Cflat.cpp
+++ b/Cflat.cpp
@@ -7869,29 +7869,31 @@ double Environment::getValueAsDecimal(const Value& pValue)
 void Environment::setValueAsInteger(int64_t pInteger, Value* pOutValue)
 {
    const size_t typeUsageSize = pOutValue->mTypeUsage.getSize();
-
-   if(typeUsageSize == sizeof(int32_t))
-   {
-      const int32_t value = (int32_t)pInteger;
-      pOutValue->assign(&value);
-   }
-   else if(typeUsageSize == sizeof(int64_t))
-   {
-      pOutValue->assign(&pInteger);
-   }
-   else if(typeUsageSize == sizeof(int16_t))
-   {
-      const int16_t value = (int16_t)pInteger;
-      pOutValue->assign(&value);
-   }
-   else if(typeUsageSize == sizeof(int8_t))
-   {
-      const int8_t value = (int8_t)pInteger;
-      pOutValue->assign(&value);
-   }
-   else
-   {
-      CflatAssert(false); // Unsupported
+   
+   switch (typeUsageSize) {
+      case sizeof(int8_t): {
+         const int8_t value = (int8_t)pInteger;
+         pOutValue->assign(&value);
+         break;
+      }
+      case sizeof(int16_t): {
+         const int16_t value = (int16_t)pInteger;
+         pOutValue->assign(&value);
+         break;
+      }
+      case sizeof(int32_t): {
+         const int32_t value = (int32_t)pInteger;
+         pOutValue->assign(&value);
+         break;
+      }
+      case sizeof(int64_t): {
+         pOutValue->assign(&pInteger);
+         break;
+      }
+      default: {
+         CflatAssert(false); // Unsupported
+         break;
+      }
    }
 }
 

--- a/Cflat.cpp
+++ b/Cflat.cpp
@@ -1365,11 +1365,7 @@ UsingDirective::UsingDirective(Namespace* pNamespace)
 //  Function
 //
 Function::Function(const Identifier& pIdentifier)
-   : mNamespace(nullptr)
-   , mIdentifier(pIdentifier)
-   , mProgram(nullptr)
-   , mLine(0u)
-   , execute(nullptr)
+   : mIdentifier(pIdentifier)
 {
 }
 
@@ -2768,7 +2764,6 @@ Context::Context(ContextType pType, Namespace* pGlobalNamespace)
 //
 ParsingContext::ParsingContext(Namespace* pGlobalNamespace)
    : Context(ContextType::Parsing, pGlobalNamespace)
-   , mTokenIndex(0u)
 {
 }
 
@@ -2779,7 +2774,6 @@ ParsingContext::ParsingContext(Namespace* pGlobalNamespace)
 CallStackEntry::CallStackEntry(const Program* pProgram, const Function* pFunction)
    : mProgram(pProgram)
    , mFunction(pFunction)
-   , mLine(0u)
 {
 }
 
@@ -2801,7 +2795,6 @@ Environment::Environment()
    : mTypesParsingContext(&mGlobalNamespace)
    , mExecutionContext(&mGlobalNamespace)
    , mGlobalNamespace("", nullptr, this)
-   , mExecutionHook(nullptr)
 {
    static_assert(kPreprocessorErrorStringsCount == (size_t)Environment::PreprocessorError::Count,
       "Missing preprocessor error strings");

--- a/Cflat.cpp
+++ b/Cflat.cpp
@@ -40,16 +40,6 @@ namespace Cflat
    //
    //  Global functions
    //
-   template<typename T>
-   inline T min(T pA, T pB)
-   {
-      return pA < pB ? pA : pB;
-   }
-   template<typename T>
-   inline T max(T pA, T pB)
-   {
-      return pA > pB ? pA : pB;
-   }
 
    Hash hash(const char* pString)
    {

--- a/Cflat.cpp
+++ b/Cflat.cpp
@@ -59,7 +59,7 @@ namespace Cflat
    }
 
    template<typename T>
-   void toArgsVector(const CflatSTLVector(T) pSTLVector, CflatArgsVector(T)& pArgsVector)
+   void toArgsVector(const Vector<T> pSTLVector, CflatArgsVector(T)& pArgsVector)
    {
       const size_t elementsCount = pSTLVector.size();
       pArgsVector.resize(elementsCount);
@@ -432,8 +432,8 @@ namespace Cflat
    struct ExpressionFunctionCall : Expression
    {
       Identifier mFunctionIdentifier;
-      CflatSTLVector(Expression*) mArguments;
-      CflatSTLVector(TypeUsage) mTemplateTypes;
+      Vector<Expression*> mArguments;
+      Vector<TypeUsage> mTemplateTypes;
       Function* mFunction{};
 
       ExpressionFunctionCall(const Identifier& pFunctionIdentifier)
@@ -455,8 +455,8 @@ namespace Cflat
    struct ExpressionMethodCall : Expression
    {
       Expression* mMemberAccess;
-      CflatSTLVector(Expression*) mArguments;
-      CflatSTLVector(TypeUsage) mTemplateTypes;
+      Vector<Expression*> mArguments;
+      Vector<TypeUsage> mTemplateTypes;
       Method* mMethod{};
 
       ExpressionMethodCall(Expression* pMemberAccess)
@@ -484,7 +484,7 @@ namespace Cflat
    struct ExpressionArrayInitialization : Expression
    {
       Type* mElementType{};
-      CflatSTLVector(Expression*) mValues;
+      Vector<Expression*> mValues;
 
       ExpressionArrayInitialization()
       {
@@ -504,7 +504,7 @@ namespace Cflat
    struct ExpressionObjectConstruction : Expression
    {
       Type* mObjectType;
-      CflatSTLVector(Expression*) mArguments;
+      Vector<Expression*> mArguments;
       Method* mConstructor{};
 
       ExpressionObjectConstruction(Type* pObjectType)
@@ -586,7 +586,7 @@ namespace Cflat
 
    struct StatementBlock : Statement
    {
-      CflatSTLVector(Statement*) mStatements;
+      Vector<Statement*> mStatements;
       bool mAlterScope;
 
       StatementBlock(bool pAlterScope)
@@ -690,8 +690,8 @@ namespace Cflat
    {
       TypeUsage mReturnType;
       Identifier mFunctionIdentifier;
-      CflatSTLVector(Identifier) mParameterIdentifiers;
-      CflatSTLVector(TypeUsage) mParameterTypes;
+      Vector<Identifier> mParameterIdentifiers;
+      Vector<TypeUsage> mParameterTypes;
       StatementBlock* mBody{};
       Function* mFunction{};
 
@@ -768,11 +768,11 @@ namespace Cflat
       struct CaseSection
       {
          Expression* mExpression;
-         CflatSTLVector(Statement*) mStatements;
+         Vector<Statement*> mStatements;
       };
 
       Expression* mCondition;
-      CflatSTLVector(CaseSection) mCaseSections;
+      Vector<CaseSection> mCaseSections;
 
       StatementSwitch(Expression* pCondition)
          : mCondition(pCondition)
@@ -1457,7 +1457,7 @@ FunctionsHolder::~FunctionsHolder()
 {
    for(FunctionsRegistry::iterator it = mFunctions.begin(); it != mFunctions.end(); it++)
    {
-      CflatSTLVector(Function*)& functions = it->second;
+      Vector<Function*>& functions = it->second;
 
       for(size_t i = 0u; i < functions.size(); i++)
       {
@@ -1478,7 +1478,7 @@ Function* FunctionsHolder::getFunction(const Identifier& pIdentifier,
    const CflatArgsVector(TypeUsage)& pParameterTypes, const CflatArgsVector(TypeUsage)& pTemplateTypes)
 {
    Function* function = nullptr;
-   CflatSTLVector(Function*)* functions = getFunctions(pIdentifier);
+   Vector<Function*>* functions = getFunctions(pIdentifier);
 
    if(functions)
    {
@@ -1562,17 +1562,17 @@ Function* FunctionsHolder::getFunction(const Identifier& pIdentifier,
    return getFunction(pIdentifier, typeUsages, pTemplateTypes);
 }
 
-CflatSTLVector(Function*)* FunctionsHolder::getFunctions(const Identifier& pIdentifier)
+Vector<Function*>* FunctionsHolder::getFunctions(const Identifier& pIdentifier)
 {
    FunctionsRegistry::iterator it = mFunctions.find(pIdentifier.mHash);
    return it != mFunctions.end() ? &it->second : nullptr;
 }
 
-void FunctionsHolder::getAllFunctions(CflatSTLVector(Function*)* pOutFunctions)
+void FunctionsHolder::getAllFunctions(Vector<Function*>* pOutFunctions)
 {
    for(FunctionsRegistry::const_iterator it = mFunctions.begin(); it != mFunctions.end(); it++)
    {
-      const CflatSTLVector(Function*)& functions = it->second;
+      const Vector<Function*>& functions = it->second;
 
       for(size_t i = 0u; i < functions.size(); i++)
       {
@@ -1589,7 +1589,7 @@ Function* FunctionsHolder::registerFunction(const Identifier& pIdentifier)
 
    if(it == mFunctions.end())
    {
-      CflatSTLVector(Function*) functions;
+      Vector<Function*> functions;
       functions.push_back(function);
       mFunctions[pIdentifier.mHash] = functions;
    }
@@ -1694,7 +1694,7 @@ void InstancesHolder::releaseInstances(uint32_t pScopeLevel, bool pExecuteDestru
    }
 }
 
-void InstancesHolder::getAllInstances(CflatSTLVector(Instance*)* pOutInstances)
+void InstancesHolder::getAllInstances(Vector<Instance*>* pOutInstances)
 {
    for(size_t i = 0u; i < mInstances.size(); i++)
    {
@@ -1821,7 +1821,7 @@ Function* Struct::getStaticMethod(const Identifier& pIdentifier,
    return mFunctionsHolder.getFunction(pIdentifier, pArguments, pTemplateTypes);
 }
 
-CflatSTLVector(Function*)* Struct::getStaticMethods(const Identifier& pIdentifier)
+Vector<Function*>* Struct::getStaticMethods(const Identifier& pIdentifier)
 {
    return mFunctionsHolder.getFunctions(pIdentifier);
 }
@@ -1986,7 +1986,7 @@ const char* kCflatKeywords[] =
 };
 const size_t kCflatKeywordsCount = sizeof(kCflatKeywords) / sizeof(const char*);
 
-void Tokenizer::tokenize(const char* pCode, CflatSTLVector(Token)& pTokens)
+void Tokenizer::tokenize(const char* pCode, Vector<Token>& pTokens)
 {
    char* cursor = const_cast<char*>(pCode);
    uint16_t currentLine = 1u;
@@ -2513,7 +2513,7 @@ Function* Namespace::getFunction(const Identifier& pIdentifier,
    return function;
 }
 
-CflatSTLVector(Function*)* Namespace::getFunctions(const Identifier& pIdentifier,
+Vector<Function*>* Namespace::getFunctions(const Identifier& pIdentifier,
    bool pExtendSearchToParent)
 {
    const char* lastSeparator = pIdentifier.findLastSeparator();
@@ -2534,7 +2534,7 @@ CflatSTLVector(Function*)* Namespace::getFunctions(const Identifier& pIdentifier
          return ns->getFunctions(functionIdentifier);
       }
 
-      CflatSTLVector(Function*)* functions = nullptr;
+      Vector<Function*>* functions = nullptr;
 
       if(pExtendSearchToParent && mParent)
       {
@@ -2554,7 +2554,7 @@ CflatSTLVector(Function*)* Namespace::getFunctions(const Identifier& pIdentifier
       return functions;
    }
 
-   CflatSTLVector(Function*)* functions = mFunctionsHolder.getFunctions(pIdentifier);
+   Vector<Function*>* functions = mFunctionsHolder.getFunctions(pIdentifier);
 
    if(!functions && pExtendSearchToParent && mParent)
    {
@@ -2727,7 +2727,7 @@ void Namespace::releaseInstances(uint32_t pScopeLevel, bool pExecuteDestructors)
    }
 }
 
-void Namespace::getAllNamespaces(CflatSTLVector(Namespace*)* pOutNamespaces)
+void Namespace::getAllNamespaces(Vector<Namespace*>* pOutNamespaces)
 {
    for(NamespacesRegistry::const_iterator it = mNamespaces.begin(); it != mNamespaces.end(); it++)
    {
@@ -2735,12 +2735,12 @@ void Namespace::getAllNamespaces(CflatSTLVector(Namespace*)* pOutNamespaces)
    }
 }
 
-void Namespace::getAllInstances(CflatSTLVector(Instance*)* pOutInstances)
+void Namespace::getAllInstances(Vector<Instance*>* pOutInstances)
 {
    mInstancesHolder.getAllInstances(pOutInstances);
 }
 
-void Namespace::getAllFunctions(CflatSTLVector(Function*)* pOutFunctions)
+void Namespace::getAllFunctions(Vector<Function*>* pOutFunctions)
 {
    mFunctionsHolder.getAllFunctions(pOutFunctions);
 }
@@ -2834,7 +2834,7 @@ void Environment::defineMacro(const char* pDefinition, const char* pBody)
    // process definition
    const size_t definitionLength = strlen(pDefinition);
 
-   CflatSTLVector(CflatSTLString) parameters;
+   Vector<CflatSTLString> parameters;
    int8_t currentParameterIndex = -1;
 
    for(size_t i = 0u; i < definitionLength; i++)
@@ -2962,7 +2962,7 @@ void Environment::registerBuiltInTypes()
 
 TypeUsage Environment::parseTypeUsage(ParsingContext& pContext, size_t pTokenLastIndex)
 {
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t& tokenIndex = pContext.mTokenIndex;
    size_t cachedTokenIndex = tokenIndex;
 
@@ -3182,7 +3182,7 @@ void Environment::preprocess(ParsingContext& pContext, const char* pCode)
             cursor += macro.mName.length();
 
             // parse arguments
-            CflatSTLVector(CflatSTLString) arguments;
+            Vector<CflatSTLString> arguments;
 
             if(pCode[cursor] == '(')
             {
@@ -3315,7 +3315,7 @@ Expression* Environment::parseExpression(ParsingContext& pContext, size_t pToken
 
 Expression* Environment::parseExpressionSingleToken(ParsingContext& pContext)
 {
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t& tokenIndex = pContext.mTokenIndex;
    const Token& token = tokens[tokenIndex];
    Expression* expression = nullptr;
@@ -3445,7 +3445,7 @@ Expression* Environment::parseExpressionSingleToken(ParsingContext& pContext)
 
 Expression* Environment::parseExpressionMultipleTokens(ParsingContext& pContext, size_t pTokenLastIndex)
 {
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t& tokenIndex = pContext.mTokenIndex;
    const Token& token = tokens[tokenIndex];
    Expression* expression = nullptr;
@@ -4261,7 +4261,7 @@ Expression* Environment::parseExpressionUnaryOperator(ParsingContext& pContext, 
 Expression* Environment::parseExpressionCast(ParsingContext& pContext, CastType pCastType,
    size_t pTokenLastIndex)
 {
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   Vector<Token>& tokens = pContext.mTokens;
    size_t& tokenIndex = pContext.mTokenIndex;
    Expression* expression = nullptr;
 
@@ -4469,7 +4469,7 @@ Expression* Environment::parseExpressionObjectConstruction(ParsingContext& pCont
 size_t Environment::findClosureTokenIndex(ParsingContext& pContext, char pOpeningChar, char pClosureChar,
    size_t pTokenIndexLimit)
 {
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t closureTokenIndex = 0u;
 
    if(pTokenIndexLimit == 0u)
@@ -4515,7 +4515,7 @@ size_t Environment::findClosureTokenIndex(ParsingContext& pContext, char pOpenin
 size_t Environment::findOpeningTokenIndex(ParsingContext& pContext, char pOpeningChar, char pClosureChar,
    size_t pClosureIndex)
 {
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t openingTokenIndex = pClosureIndex;
 
    if(openingTokenIndex > 0u)
@@ -4552,7 +4552,7 @@ size_t Environment::findOpeningTokenIndex(ParsingContext& pContext, char pOpenin
 size_t Environment::findSeparationTokenIndex(ParsingContext& pContext, char pSeparationChar,
    size_t pClosureIndex)
 {
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t separationTokenIndex = 0u;
 
    uint32_t scopeLevel = 0u;
@@ -4610,7 +4610,7 @@ bool Environment::isTemplate(ParsingContext& pContext, size_t pOpeningTokenIndex
    if(pClosureTokenIndex <= pOpeningTokenIndex)
       return false;
 
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
 
    const Token& openingToken = tokens[pOpeningTokenIndex];
 
@@ -4641,7 +4641,7 @@ bool Environment::isTemplate(ParsingContext& pContext, size_t pOpeningTokenIndex
 
 bool Environment::isTemplate(ParsingContext& pContext, size_t pTokenLastIndex)
 {
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t& tokenIndex = pContext.mTokenIndex;
 
    if(tokens[tokenIndex].mLength != 1u || tokens[tokenIndex].mStart[0] != '<')
@@ -4698,7 +4698,7 @@ bool Environment::isCastAllowed(CastType pCastType, const TypeUsage& pFrom, cons
 
 Statement* Environment::parseStatement(ParsingContext& pContext)
 {
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t& tokenIndex = pContext.mTokenIndex;
    const Token& token = tokens[tokenIndex];
 
@@ -4897,7 +4897,7 @@ StatementBlock* Environment::parseStatementBlock(ParsingContext& pContext,
       return nullptr;
    }
 
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t& tokenIndex = pContext.mTokenIndex;
    const Token& token = tokens[tokenIndex];
 
@@ -4968,7 +4968,7 @@ StatementBlock* Environment::parseStatementBlock(ParsingContext& pContext,
 
 StatementUsingDirective* Environment::parseStatementUsingDirective(ParsingContext& pContext)
 {
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t& tokenIndex = pContext.mTokenIndex;
    const Token& token = tokens[tokenIndex];
 
@@ -5086,7 +5086,7 @@ StatementUsingDirective* Environment::parseStatementUsingDirective(ParsingContex
 
 StatementTypeDefinition* Environment::parseStatementTypeDefinition(ParsingContext& pContext)
 {
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t& tokenIndex = pContext.mTokenIndex;
 
    StatementTypeDefinition* statement = nullptr;
@@ -5130,7 +5130,7 @@ StatementTypeDefinition* Environment::parseStatementTypeDefinition(ParsingContex
 
 StatementNamespaceDeclaration* Environment::parseStatementNamespaceDeclaration(ParsingContext& pContext)
 {
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t& tokenIndex = pContext.mTokenIndex;
    const Token& token = tokens[tokenIndex];
 
@@ -5165,7 +5165,7 @@ StatementNamespaceDeclaration* Environment::parseStatementNamespaceDeclaration(P
 StatementVariableDeclaration* Environment::parseStatementVariableDeclaration(ParsingContext& pContext,
    TypeUsage& pTypeUsage, const Identifier& pIdentifier, bool pStatic)
 {
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t& tokenIndex = pContext.mTokenIndex;
    const Token& token = tokens[tokenIndex];
 
@@ -5393,7 +5393,7 @@ StatementVariableDeclaration* Environment::parseStatementVariableDeclaration(Par
 StatementFunctionDeclaration* Environment::parseStatementFunctionDeclaration(ParsingContext& pContext,
    const TypeUsage& pReturnType)
 {
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t& tokenIndex = pContext.mTokenIndex;
    const Token& token = tokens[tokenIndex];
 
@@ -5464,7 +5464,7 @@ StatementFunctionDeclaration* Environment::parseStatementFunctionDeclaration(Par
 
 StatementStructDeclaration* Environment::parseStatementStructDeclaration(ParsingContext& pContext)
 {
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t& tokenIndex = pContext.mTokenIndex;
    const Token& token = tokens[tokenIndex];
 
@@ -5546,7 +5546,7 @@ StatementIf* Environment::parseStatementIf(ParsingContext& pContext)
       return nullptr;
    }
 
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t& tokenIndex = pContext.mTokenIndex;
 
    if(tokens[tokenIndex].mStart[0] != '(')
@@ -5599,7 +5599,7 @@ StatementSwitch* Environment::parseStatementSwitch(ParsingContext& pContext)
       return nullptr;
    }
 
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t& tokenIndex = pContext.mTokenIndex;
 
    if(tokens[tokenIndex].mStart[0] != '(')
@@ -5708,7 +5708,7 @@ StatementWhile* Environment::parseStatementWhile(ParsingContext& pContext)
       return nullptr;
    }
 
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t& tokenIndex = pContext.mTokenIndex;
 
    if(tokens[tokenIndex].mStart[0] != '(')
@@ -5745,7 +5745,7 @@ StatementDoWhile* Environment::parseStatementDoWhile(ParsingContext& pContext)
       return nullptr;
    }
 
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t& tokenIndex = pContext.mTokenIndex;
 
    Statement* loopStatement = parseStatement(pContext);
@@ -5809,7 +5809,7 @@ Statement* Environment::parseStatementFor(ParsingContext& pContext)
       return nullptr;
    }
 
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t& tokenIndex = pContext.mTokenIndex;
 
    if(tokens[tokenIndex].mStart[0] != '(')
@@ -5909,7 +5909,7 @@ StatementFor* Environment::parseStatementForRegular(ParsingContext& pContext,
 StatementForRangeBased* Environment::parseStatementForRangeBased(ParsingContext& pContext,
    size_t pVariableClosureTokenIndex)
 {
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t& tokenIndex = pContext.mTokenIndex;
 
    TypeUsage variableTypeUsage = parseTypeUsage(pContext, pVariableClosureTokenIndex - 1u);
@@ -6036,7 +6036,7 @@ StatementBreak* Environment::parseStatementBreak(ParsingContext& pContext)
       return nullptr;
    }
 
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t& tokenIndex = pContext.mTokenIndex;
 
    if(tokens[tokenIndex].mStart[0] != ';')
@@ -6059,7 +6059,7 @@ StatementContinue* Environment::parseStatementContinue(ParsingContext& pContext)
       return nullptr;
    }
 
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t& tokenIndex = pContext.mTokenIndex;
 
    if(tokens[tokenIndex].mStart[0] != ';')
@@ -6101,9 +6101,9 @@ StatementReturn* Environment::parseStatementReturn(ParsingContext& pContext)
 }
 
 bool Environment::parseFunctionCallArguments(ParsingContext& pContext,
-   CflatSTLVector(Expression*)* pArguments, CflatSTLVector(TypeUsage)* pTemplateTypes)
+   Vector<Expression*>* pArguments, Vector<TypeUsage>* pTemplateTypes)
 {
-   CflatSTLVector(Token)& tokens = pContext.mTokens;
+   auto& tokens = pContext.mTokens;
    size_t& tokenIndex = pContext.mTokenIndex;
 
    if(tokens[tokenIndex].mStart[0] == '<')
@@ -7206,7 +7206,7 @@ void Environment::getAddressOfValue(ExecutionContext& pContext, const Value& pIn
 }
 
 void Environment::getArgumentValues(ExecutionContext& pContext,
-   const CflatSTLVector(Expression*)& pExpressions, CflatArgsVector(Value)& pValues)
+   const Vector<Expression*>& pExpressions, CflatArgsVector(Value)& pValues)
 {
    pValues.resize(pExpressions.size());
 
@@ -7218,7 +7218,7 @@ void Environment::getArgumentValues(ExecutionContext& pContext,
 }
 
 void Environment::prepareArgumentsForFunctionCall(ExecutionContext& pContext,
-   const CflatSTLVector(TypeUsage)& pParameters, const CflatArgsVector(Value)& pOriginalValues,
+   const Vector<TypeUsage>& pParameters, const CflatArgsVector(Value)& pOriginalValues,
    CflatArgsVector(Value)& pPreparedValues)
 {
    CflatAssert(pParameters.size() == pOriginalValues.size());
@@ -8685,7 +8685,7 @@ Function* Environment::getFunction(const Identifier& pIdentifier,
    return mGlobalNamespace.getFunction(pIdentifier, pArguments);
 }
 
-CflatSTLVector(Function*)* Environment::getFunctions(const Identifier& pIdentifier)
+Vector<Function*>* Environment::getFunctions(const Identifier& pIdentifier)
 {
    return mGlobalNamespace.getFunctions(pIdentifier);
 }
@@ -8808,7 +8808,7 @@ bool Environment::evaluateExpression(const char* pExpression, Value* pOutValue)
    preprocess(parsingContext, pExpression);
    tokenize(parsingContext);
    
-   CflatSTLVector(Token)& tokens = parsingContext.mTokens;
+   auto& tokens = parsingContext.mTokens;
    
    if(!tokens.empty())
    {

--- a/Cflat.cpp
+++ b/Cflat.cpp
@@ -1619,11 +1619,6 @@ Function* FunctionsHolder::registerFunction(const Identifier& pIdentifier)
 //
 //  InstancesHolder
 //
-InstancesHolder::InstancesHolder(size_t pMaxInstances)
-   : mMaxInstances(pMaxInstances)
-{
-}
-
 InstancesHolder::~InstancesHolder()
 {
    releaseInstances(0u, true);
@@ -1650,13 +1645,6 @@ Value* InstancesHolder::getVariable(const Identifier& pIdentifier)
 
 Instance* InstancesHolder::registerInstance(const TypeUsage& pTypeUsage, const Identifier& pIdentifier)
 {
-   CflatAssert(mInstances.size() < mMaxInstances);
-
-   if(mInstances.capacity() == 0u)
-   {
-      mInstances.reserve(mMaxInstances);
-   }
-
    mInstances.emplace_back(pTypeUsage, pIdentifier);
    return &mInstances.back();
 }
@@ -1764,7 +1752,6 @@ EnumClass::EnumClass(Namespace* pNamespace, const Identifier& pIdentifier)
 //
 Struct::Struct(Namespace* pNamespace, const Identifier& pIdentifier)
    : Type(pNamespace, pIdentifier)
-   , mInstancesHolder(kMaxStaticMembers)
 {
    mCategory = TypeCategory::StructOrClass;
 }
@@ -2226,7 +2213,6 @@ Namespace::Namespace(const Identifier& pIdentifier, Namespace* pParent, Environm
    , mFullIdentifier(pIdentifier)
    , mParent(pParent)
    , mEnvironment(pEnvironment)
-   , mInstancesHolder(kMaxGlobalInstancesPerNamespace)
 {
    if(pParent && pParent->getParent())
    {
@@ -2782,7 +2768,6 @@ Context::Context(ContextType pType, Namespace* pGlobalNamespace)
    , mProgram(nullptr)
    , mBlockLevel(0u)
    , mScopeLevel(0u)
-   , mLocalInstancesHolder(kMaxLocalInstances)
 {
    mNamespaceStack.push_back(pGlobalNamespace);
 }

--- a/Cflat.cpp
+++ b/Cflat.cpp
@@ -331,10 +331,9 @@ namespace Cflat
    struct ExpressionSizeOf : Expression
    {
       TypeUsage mTypeUsage;
-      Expression* mExpression;
+      Expression* mExpression{};
 
       ExpressionSizeOf()
-         : mExpression(nullptr)
       {
          mType = ExpressionType::SizeOf;
       }
@@ -445,11 +444,10 @@ namespace Cflat
       Identifier mFunctionIdentifier;
       CflatSTLVector(Expression*) mArguments;
       CflatSTLVector(TypeUsage) mTemplateTypes;
-      Function* mFunction;
+      Function* mFunction{};
 
       ExpressionFunctionCall(const Identifier& pFunctionIdentifier)
          : mFunctionIdentifier(pFunctionIdentifier)
-         , mFunction(nullptr)
       {
          mType = ExpressionType::FunctionCall;
       }
@@ -469,11 +467,10 @@ namespace Cflat
       Expression* mMemberAccess;
       CflatSTLVector(Expression*) mArguments;
       CflatSTLVector(TypeUsage) mTemplateTypes;
-      Method* mMethod;
+      Method* mMethod{};
 
       ExpressionMethodCall(Expression* pMemberAccess)
          : mMemberAccess(pMemberAccess)
-         , mMethod(nullptr)
       {
          mType = ExpressionType::MethodCall;
       }
@@ -496,11 +493,10 @@ namespace Cflat
 
    struct ExpressionArrayInitialization : Expression
    {
-      Type* mElementType;
+      Type* mElementType{};
       CflatSTLVector(Expression*) mValues;
 
       ExpressionArrayInitialization()
-         : mElementType(nullptr)
       {
          mType = ExpressionType::ArrayInitialization;
       }
@@ -519,11 +515,10 @@ namespace Cflat
    {
       Type* mObjectType;
       CflatSTLVector(Expression*) mArguments;
-      Method* mConstructor;
+      Method* mConstructor{};
 
       ExpressionObjectConstruction(Type* pObjectType)
          : mObjectType(pObjectType)
-         , mConstructor(nullptr)
       {
          mType = ExpressionType::ObjectConstruction;
       }
@@ -565,15 +560,9 @@ namespace Cflat
    protected:
       StatementType mType;
 
-      Statement()
-         : mProgram(nullptr)
-         , mLine(0u)
-      {
-      }
-
    public:
-      Program* mProgram;
-      uint16_t mLine;
+      Program* mProgram{};
+      uint16_t mLine{};
 
       virtual ~Statement()
       {
@@ -628,7 +617,7 @@ namespace Cflat
 
    struct StatementUsingDirective : Statement
    {
-      Namespace* mNamespace;
+      Namespace* mNamespace{};
       Identifier mAliasIdentifier;
       TypeUsage mAliasTypeUsage;
 
@@ -639,8 +628,7 @@ namespace Cflat
       }
 
       StatementUsingDirective(const Identifier& pAliasIdentifier, const TypeUsage& pAliasTypeUsage)
-         : mNamespace(nullptr)
-         , mAliasIdentifier(pAliasIdentifier)
+         : mAliasIdentifier(pAliasIdentifier)
          , mAliasTypeUsage(pAliasTypeUsage)
       {
          mType = StatementType::UsingDirective;
@@ -690,11 +678,10 @@ namespace Cflat
    struct StatementNamespaceDeclaration : Statement
    {
       Identifier mNamespaceIdentifier;
-      StatementBlock* mBody;
+      StatementBlock* mBody{};
 
       StatementNamespaceDeclaration(const Identifier& pNamespaceIdentifier)
          : mNamespaceIdentifier(pNamespaceIdentifier)
-         , mBody(nullptr)
       {
          mType = StatementType::NamespaceDeclaration;
       }
@@ -715,14 +702,12 @@ namespace Cflat
       Identifier mFunctionIdentifier;
       CflatSTLVector(Identifier) mParameterIdentifiers;
       CflatSTLVector(TypeUsage) mParameterTypes;
-      StatementBlock* mBody;
-      Function* mFunction;
+      StatementBlock* mBody{};
+      Function* mFunction{};
 
       StatementFunctionDeclaration(const TypeUsage& pReturnType, const Identifier& pFunctionIdentifier)
          : mReturnType(pReturnType)
          , mFunctionIdentifier(pFunctionIdentifier)
-         , mBody(nullptr)
-         , mFunction(nullptr)
       {
          mType = StatementType::FunctionDeclaration;
       }
@@ -744,10 +729,9 @@ namespace Cflat
 
    struct StatementStructDeclaration : Statement
    {
-      Struct* mStruct;
+      Struct* mStruct{};
 
       StatementStructDeclaration()
-         : mStruct(nullptr)
       {
          mType = StatementType::StructDeclaration;
       }
@@ -1050,8 +1034,7 @@ void (*Memory::free)(void* pPtr) = ::free;
 Identifier::NamesRegistry* Identifier::smNames = nullptr;
 
 Identifier::Identifier()
-   : mHash(0u)
-   , mName(getNamesRegistry()->mMemory)
+   : mName(getNamesRegistry()->mMemory)
 {
 }
 
@@ -1137,9 +1120,7 @@ Type::~Type()
 
 Type::Type(Namespace* pNamespace, const Identifier& pIdentifier)
    : mNamespace(pNamespace)
-   , mParent(nullptr)
    , mIdentifier(pIdentifier)
-   , mSize(0u)
 {
 }
 
@@ -1170,14 +1151,6 @@ bool Type::compatibleWith(const Type& pOther) const
 //  TypeUsage
 //
 const CflatArgsVector(TypeUsage) TypeUsage::kEmptyList;
-
-TypeUsage::TypeUsage()
-   : mType(nullptr)
-   , mArraySize(1u)
-   , mPointerLevel(0u)
-   , mFlags(0u)
-{
-}
 
 size_t TypeUsage::getSize() const
 {
@@ -1235,14 +1208,12 @@ bool TypeUsage::operator!=(const TypeUsage& pOther) const
 //  TypeAlias
 //
 TypeAlias::TypeAlias()
-  : mScopeLevel(0u)
 {
 }
 
 TypeAlias::TypeAlias(const Identifier& pIdentifier, const TypeUsage& pTypeUsage)
   : mIdentifier(pIdentifier)
   , mTypeUsage(pTypeUsage)
-  , mScopeLevel(0u)
 {
 }
 
@@ -1252,7 +1223,6 @@ TypeAlias::TypeAlias(const Identifier& pIdentifier, const TypeUsage& pTypeUsage)
 //
 Member::Member(const Identifier& pIdentifier)
    : mIdentifier(pIdentifier)
-   , mOffset(0u)
 {
 }
 
@@ -1265,16 +1235,12 @@ const CflatArgsVector(Value) Value::kEmptyList;
 Value::Value()
    : mValueBufferType(ValueBufferType::Uninitialized)
    , mValueInitializationHint(ValueInitializationHint::None)
-   , mValueBuffer(nullptr)
-   , mStack(nullptr)
 {
 }
 
 Value::Value(const Value& pOther)
    : mValueBufferType(ValueBufferType::Uninitialized)
    , mValueInitializationHint(ValueInitializationHint::None)
-   , mValueBuffer(nullptr)
-   , mStack(nullptr)
 {
    *this = pOther;
 }
@@ -1442,14 +1408,12 @@ Method::~Method()
 //  Instance
 //
 Instance::Instance()
-   : mScopeLevel(0u)
 {
 }
 
 Instance::Instance(const TypeUsage& pTypeUsage, const Identifier& pIdentifier)
    : mTypeUsage(pTypeUsage)
    , mIdentifier(pIdentifier)
-   , mScopeLevel(0u)
 {
 }
 

--- a/Cflat.cpp
+++ b/Cflat.cpp
@@ -2834,7 +2834,7 @@ void Environment::defineMacro(const char* pDefinition, const char* pBody)
    // process definition
    const size_t definitionLength = strlen(pDefinition);
 
-   Vector<CflatSTLString> parameters;
+   Vector<String> parameters;
    int8_t currentParameterIndex = -1;
 
    for(size_t i = 0u; i < definitionLength; i++)
@@ -3123,7 +3123,7 @@ void Environment::throwCompileErrorUnexpectedSymbol(ParsingContext& pContext)
 
 void Environment::preprocess(ParsingContext& pContext, const char* pCode)
 {
-   CflatSTLString& preprocessedCode = pContext.mPreprocessedCode;
+   String& preprocessedCode = pContext.mPreprocessedCode;
 
    const size_t codeLength = strlen(pCode);
    preprocessedCode.clear();
@@ -3182,7 +3182,7 @@ void Environment::preprocess(ParsingContext& pContext, const char* pCode)
             cursor += macro.mName.length();
 
             // parse arguments
-            Vector<CflatSTLString> arguments;
+            Vector<String> arguments;
 
             if(pCode[cursor] == '(')
             {
@@ -3209,7 +3209,7 @@ void Environment::preprocess(ParsingContext& pContext, const char* pCode)
             // append the replaced strings
             for(size_t j = 0u; j < macro.mBody.size(); j++)
             {
-               const CflatSTLString& bodyChunk = macro.mBody[j];
+               const String& bodyChunk = macro.mBody[j];
 
                if(bodyChunk[0] == '$')
                {
@@ -3583,7 +3583,7 @@ Expression* Environment::parseExpressionMultipleTokens(ParsingContext& pContext,
          if(!leftTypeUsage.isConst())
          {
             const Token& operatorToken = pContext.mTokens[assignmentOperatorTokenIndex];
-            CflatSTLString operatorStr(operatorToken.mStart, operatorToken.mLength);
+            String operatorStr(operatorToken.mStart, operatorToken.mLength);
 
             tokenIndex = assignmentOperatorTokenIndex + 1u;
             Expression* right = parseExpression(pContext, pTokenLastIndex);
@@ -3642,7 +3642,7 @@ Expression* Environment::parseExpressionMultipleTokens(ParsingContext& pContext,
          const TypeUsage leftTypeUsage = getTypeUsage(pContext, left);
 
          const Token& operatorToken = pContext.mTokens[binaryOperatorTokenIndex];
-         CflatSTLString operatorStr(operatorToken.mStart, operatorToken.mLength);
+         String operatorStr(operatorToken.mStart, operatorToken.mLength);
 
          tokenIndex = binaryOperatorTokenIndex + 1u;
          Expression* right = parseExpression(pContext, pTokenLastIndex);
@@ -3773,7 +3773,7 @@ Expression* Environment::parseExpressionMultipleTokens(ParsingContext& pContext,
       else
       {
          const Token& operatorToken = token;
-         CflatSTLString operatorStr(operatorToken.mStart, operatorToken.mLength);
+         String operatorStr(operatorToken.mStart, operatorToken.mLength);
          tokenIndex++;
          Expression* operandExpression = parseExpression(pContext, pTokenLastIndex);
 
@@ -3980,7 +3980,7 @@ Expression* Environment::parseExpressionMultipleTokens(ParsingContext& pContext,
    else if(tokens[pTokenLastIndex].mType == TokenType::Operator)
    {
       const Token& operatorToken = tokens[pTokenLastIndex];
-      CflatSTLString operatorStr(operatorToken.mStart, operatorToken.mLength);
+      String operatorStr(operatorToken.mStart, operatorToken.mLength);
       Expression* operandExpression = parseExpression(pContext, pTokenLastIndex - 1u);
 
       expression =

--- a/Cflat.cpp
+++ b/Cflat.cpp
@@ -101,14 +101,10 @@ namespace Cflat
    protected:
       ExpressionType mType;
 
-      Expression()
-      {
-      }
+      Expression() = default;
 
    public:
-      virtual ~Expression()
-      {
-      }
+      virtual ~Expression() = default;
 
       ExpressionType getType() const
       {

--- a/Cflat.cpp
+++ b/Cflat.cpp
@@ -552,7 +552,7 @@ namespace Cflat
 
    public:
       Program* mProgram{};
-      uint16_t mLine{};
+      LineType mLine{};
 
       virtual ~Statement()
       {
@@ -4703,7 +4703,7 @@ Statement* Environment::parseStatement(ParsingContext& pContext)
    const Token& token = tokens[tokenIndex];
 
    Statement* statement = nullptr;
-   const uint16_t statementLine = token.mLine;
+   const auto statementLine = token.mLine;
 
    if(token.mType == TokenType::Punctuation && (token.mStart[0] == '{' || token.mStart[0] == '}'))
    {

--- a/Cflat.h
+++ b/Cflat.h
@@ -52,8 +52,6 @@
 #define CflatSTLMap(T, U)  std::map<T, U, std::less<T>, Cflat::Memory::STLAllocator<std::pair<const T, U>>>
 #define CflatSTLString  std::basic_string<char, std::char_traits<char>, Cflat::Memory::STLAllocator<char>>
 
-#define CflatArgsVector(T)  Cflat::Memory::StackVector<T, Cflat::kArgsVectorSize>
-
 namespace Cflat
 {
    typedef uint32_t Hash;
@@ -402,14 +400,17 @@ namespace Cflat
 
    
    template <class T>
-   using Vector = std::vector<T, Cflat::Memory::STLAllocator<T>>;
+   using Vector = std::vector<T, Memory::STLAllocator<T>>;
+   
+   template <class T>
+   using ArgsVector = Memory::StackVector<T, Cflat::kArgsVectorSize>;
    
    template <class T>
    using Deque = std::deque<T, Memory::STLAllocator<T>>;
    
    
    template<typename T>
-   bool operator==(const Vector<T>& pSTLVector, const CflatArgsVector(T)& pArgsVector)
+   bool operator==(const Vector<T>& pSTLVector, const ArgsVector<T>& pArgsVector)
    {
       return pArgsVector == pSTLVector;
    }
@@ -483,7 +484,7 @@ namespace Cflat
 
    struct TypeUsage
    {
-      static const CflatArgsVector(TypeUsage) kEmptyList;
+      static const ArgsVector<TypeUsage> kEmptyList;
 
       Type* mType{};
       uint16_t mArraySize{1u};
@@ -541,7 +542,7 @@ namespace Cflat
 
    struct Value
    {
-      static const CflatArgsVector(Value) kEmptyList;
+      static const ArgsVector<Value> kEmptyList;
 
       TypeUsage mTypeUsage;
       ValueBufferType mValueBufferType;
@@ -585,7 +586,7 @@ namespace Cflat
       Vector<Identifier> mParameterIdentifiers;
       Vector<UsingDirective> mUsingDirectives;
 
-      std::function<void(const CflatArgsVector(Value)& pArgs, Value* pOutReturnValue)> execute{};
+      std::function<void(const ArgsVector<Value>& pArgs, Value* pOutReturnValue)> execute{};
 
       Function(const Identifier& pIdentifier);
       ~Function();
@@ -598,7 +599,7 @@ namespace Cflat
       Vector<TypeUsage> mTemplateTypes;
       Vector<TypeUsage> mParameters;
 
-      std::function<void(const Value& pThis, const CflatArgsVector(Value)& pArgs, Value* pOutReturnValue)> execute;
+      std::function<void(const Value& pThis, const ArgsVector<Value>& pArgs, Value* pOutReturnValue)> execute;
 
       Method(const Identifier& pIdentifier);
       ~Method();
@@ -650,7 +651,7 @@ namespace Cflat
       }
 
       template<typename T>
-      T* registerTemplate(const Identifier& pIdentifier, const CflatArgsVector(TypeUsage)& pTemplateTypes,
+      T* registerTemplate(const Identifier& pIdentifier, const ArgsVector<TypeUsage>& pTemplateTypes,
          Namespace* pNamespace, Type* pParent)
       {
          T* type = (T*)CflatMalloc(sizeof(T));
@@ -675,7 +676,7 @@ namespace Cflat
       }
 
       Type* getType(const Identifier& pIdentifier);
-      Type* getType(const Identifier& pIdentifier, const CflatArgsVector(TypeUsage)& pTemplateTypes);
+      Type* getType(const Identifier& pIdentifier, const ArgsVector<TypeUsage>& pTemplateTypes);
 
       void registerTypeAlias(const Identifier& pIdentifier, const TypeUsage& pTypeUsage);
       const TypeAlias* getTypeAlias(const Identifier& pIdentifier);
@@ -694,11 +695,11 @@ namespace Cflat
 
       Function* getFunction(const Identifier& pIdentifier);
       Function* getFunction(const Identifier& pIdentifier,
-         const CflatArgsVector(TypeUsage)& pParameterTypes,
-         const CflatArgsVector(TypeUsage)& pTemplateTypes = TypeUsage::kEmptyList);
+         const ArgsVector<TypeUsage>& pParameterTypes,
+         const ArgsVector<TypeUsage>& pTemplateTypes = TypeUsage::kEmptyList);
       Function* getFunction(const Identifier& pIdentifier,
-         const CflatArgsVector(Value)& pArguments,
-         const CflatArgsVector(TypeUsage)& pTemplateTypes = TypeUsage::kEmptyList);
+         const ArgsVector<Value>& pArguments,
+         const ArgsVector<TypeUsage>& pTemplateTypes = TypeUsage::kEmptyList);
 
       Vector<Function*>* getFunctions(const Identifier& pIdentifier);
       void getAllFunctions(Vector<Function*>* pOutFunctions);
@@ -768,12 +769,12 @@ namespace Cflat
          return mTypesHolder.registerType<T>(pIdentifier, mNamespace, this);
       }
       template<typename T>
-      T* registerTemplate(const Identifier& pIdentifier, const CflatArgsVector(TypeUsage)& pTemplateTypes)
+      T* registerTemplate(const Identifier& pIdentifier, const ArgsVector<TypeUsage>& pTemplateTypes)
       {
          return mTypesHolder.registerTemplate<T>(pIdentifier, pTemplateTypes, mNamespace, this);
       }
       Type* getType(const Identifier& pIdentifier);
-      Type* getType(const Identifier& pIdentifier, const CflatArgsVector(TypeUsage)& pTemplateTypes);
+      Type* getType(const Identifier& pIdentifier, const ArgsVector<TypeUsage>& pTemplateTypes);
 
       void registerTypeAlias(const Identifier& pIdentifier, const TypeUsage& pTypeUsage);
       const TypeAlias* getTypeAlias(const Identifier& pIdentifier);
@@ -781,11 +782,11 @@ namespace Cflat
       Function* registerStaticMethod(const Identifier& pIdentifier);
       Function* getStaticMethod(const Identifier& pIdentifier);
       Function* getStaticMethod(const Identifier& pIdentifier,
-         const CflatArgsVector(TypeUsage)& pParameterTypes,
-         const CflatArgsVector(TypeUsage)& pTemplateTypes = TypeUsage::kEmptyList);
+         const ArgsVector<TypeUsage>& pParameterTypes,
+         const ArgsVector<TypeUsage>& pTemplateTypes = TypeUsage::kEmptyList);
       Function* getStaticMethod(const Identifier& pIdentifier,
-         const CflatArgsVector(Value)& pArguments,
-         const CflatArgsVector(TypeUsage)& pTemplateTypes = TypeUsage::kEmptyList);
+         const ArgsVector<Value>& pArguments,
+         const ArgsVector<TypeUsage>& pTemplateTypes = TypeUsage::kEmptyList);
       Vector<Function*>* getStaticMethods(const Identifier& pIdentifier);
 
       void setStaticMember(const TypeUsage& pTypeUsage, const Identifier& pIdentifier,
@@ -925,7 +926,7 @@ namespace Cflat
          return mTypesHolder.registerType<T>(pIdentifier, this, nullptr);
       }
       template<typename T>
-      T* registerTemplate(const Identifier& pIdentifier, const CflatArgsVector(TypeUsage)& pTemplateTypes)
+      T* registerTemplate(const Identifier& pIdentifier, const ArgsVector<TypeUsage>& pTemplateTypes)
       {
          const char* lastSeparator = pIdentifier.findLastSeparator();
 
@@ -943,7 +944,7 @@ namespace Cflat
          return mTypesHolder.registerTemplate<T>(pIdentifier, pTemplateTypes, this, nullptr);
       }
       Type* getType(const Identifier& pIdentifier, bool pExtendSearchToParent = false);
-      Type* getType(const Identifier& pIdentifier, const CflatArgsVector(TypeUsage)& pTemplateTypes,
+      Type* getType(const Identifier& pIdentifier, const ArgsVector<TypeUsage>& pTemplateTypes,
          bool pExtendSearchToParent = false);
 
       void registerTypeAlias(const Identifier& pIdentifier, const TypeUsage& pTypeUsage);
@@ -954,12 +955,12 @@ namespace Cflat
       Function* registerFunction(const Identifier& pIdentifier);
       Function* getFunction(const Identifier& pIdentifier, bool pExtendSearchToParent = false);
       Function* getFunction(const Identifier& pIdentifier,
-         const CflatArgsVector(TypeUsage)& pParameterTypes,
-         const CflatArgsVector(TypeUsage)& pTemplateTypes = TypeUsage::kEmptyList,
+         const ArgsVector<TypeUsage>& pParameterTypes,
+         const ArgsVector<TypeUsage>& pTemplateTypes = TypeUsage::kEmptyList,
          bool pExtendSearchToParent = false);
       Function* getFunction(const Identifier& pIdentifier,
-         const CflatArgsVector(Value)& pArguments,
-         const CflatArgsVector(TypeUsage)& pTemplateTypes = TypeUsage::kEmptyList,
+         const ArgsVector<Value>& pArguments,
+         const ArgsVector<TypeUsage>& pTemplateTypes = TypeUsage::kEmptyList,
          bool pExtendSearchToParent = false);
       Vector<Function*>* getFunctions(const Identifier& pIdentifier,
          bool pExtendSearchToParent = false);
@@ -1222,13 +1223,13 @@ namespace Cflat
       TypeUsage getTypeUsage(Context& pContext, Expression* pExpression);
 
       Type* findType(const Context& pContext, const Identifier& pIdentifier,
-         const CflatArgsVector(TypeUsage)& pTemplateTypes = TypeUsage::kEmptyList);
+         const ArgsVector<TypeUsage>& pTemplateTypes = TypeUsage::kEmptyList);
       Function* findFunction(const Context& pContext, const Identifier& pIdentifier,
-         const CflatArgsVector(TypeUsage)& pParameterTypes,
-         const CflatArgsVector(TypeUsage)& pTemplateTypes = TypeUsage::kEmptyList);
+         const ArgsVector<TypeUsage>& pParameterTypes,
+         const ArgsVector<TypeUsage>& pTemplateTypes = TypeUsage::kEmptyList);
       Function* findFunction(const Context& pContext, const Identifier& pIdentifier,
-         const CflatArgsVector(Value)& pArguments,
-         const CflatArgsVector(TypeUsage)& pTemplateTypes = TypeUsage::kEmptyList);
+         const ArgsVector<Value>& pArguments,
+         const ArgsVector<TypeUsage>& pTemplateTypes = TypeUsage::kEmptyList);
 
       void registerTypeAlias(
         Context& pContext, const Identifier& pIdentifier, const TypeUsage& pTypeUsage);
@@ -1250,10 +1251,10 @@ namespace Cflat
       void getInstanceDataValue(ExecutionContext& pContext, Expression* pExpression, Value* pOutValue);
       void getAddressOfValue(ExecutionContext& pContext, const Value& pInstanceDataValue, Value* pOutValue);
       void getArgumentValues(ExecutionContext& pContext,
-         const Vector<Expression*>& pExpressions, CflatArgsVector(Value)& pValues);
+         const Vector<Expression*>& pExpressions, ArgsVector<Value>& pValues);
       void prepareArgumentsForFunctionCall(ExecutionContext& pContext,
-         const Vector<TypeUsage>& pParameters, const CflatArgsVector(Value)& pOriginalValues,
-         CflatArgsVector(Value)& pPreparedValues);
+         const Vector<TypeUsage>& pParameters, const ArgsVector<Value>& pOriginalValues,
+         ArgsVector<Value>& pPreparedValues);
       void applyUnaryOperator(ExecutionContext& pContext, const Value& pOperand, const char* pOperator,
          Value* pOutValue);
       void applyBinaryOperator(ExecutionContext& pContext, const Value& pLeft, const Value& pRight,
@@ -1283,17 +1284,17 @@ namespace Cflat
 
       static Method* getDefaultConstructor(Type* pType);
       static Method* getDestructor(Type* pType);
-      static Method* findConstructor(Type* pType, const CflatArgsVector(TypeUsage)& pParameterTypes);
-      static Method* findConstructor(Type* pType, const CflatArgsVector(Value)& pArguments);
+      static Method* findConstructor(Type* pType, const ArgsVector<TypeUsage>& pParameterTypes);
+      static Method* findConstructor(Type* pType, const ArgsVector<Value>& pArguments);
       static Method* findMethod(Type* pType, const Identifier& pIdentifier);
       static Method* findMethod(Type* pType, const Identifier& pIdentifier,
-         const CflatArgsVector(TypeUsage)& pParameterTypes,
-         const CflatArgsVector(TypeUsage)& pTemplateTypes = TypeUsage::kEmptyList);
+         const ArgsVector<TypeUsage>& pParameterTypes,
+         const ArgsVector<TypeUsage>& pTemplateTypes = TypeUsage::kEmptyList);
       static Method* findMethod(Type* pType, const Identifier& pIdentifier,
-         const CflatArgsVector(Value)& pArguments,
-         const CflatArgsVector(TypeUsage)& pTemplateTypes = TypeUsage::kEmptyList);
+         const ArgsVector<Value>& pArguments,
+         const ArgsVector<TypeUsage>& pTemplateTypes = TypeUsage::kEmptyList);
 
-      void initArgumentsForFunctionCall(Function* pFunction, CflatArgsVector(Value)& pArgs);
+      void initArgumentsForFunctionCall(Function* pFunction, ArgsVector<Value>& pArgs);
 
       void execute(ExecutionContext& pContext, const Program& pProgram);
       void execute(ExecutionContext& pContext, Statement* pStatement);
@@ -1314,19 +1315,19 @@ namespace Cflat
          return mGlobalNamespace.registerType<T>(pIdentifier);
       }
       template<typename T>
-      T* registerTemplate(const Identifier& pIdentifier, const CflatArgsVector(TypeUsage)& pTemplateTypes)
+      T* registerTemplate(const Identifier& pIdentifier, const ArgsVector<TypeUsage>& pTemplateTypes)
       {
          return mGlobalNamespace.registerTemplate<T>(pIdentifier, pTemplateTypes);
       }
       Type* getType(const Identifier& pIdentifier);
-      Type* getType(const Identifier& pIdentifier, const CflatArgsVector(TypeUsage)& pTemplateTypes);
+      Type* getType(const Identifier& pIdentifier, const ArgsVector<TypeUsage>& pTemplateTypes);
 
       TypeUsage getTypeUsage(const char* pTypeName, Namespace* pNamespace = nullptr);
 
       Function* registerFunction(const Identifier& pIdentifier);
       Function* getFunction(const Identifier& pIdentifier);
-      Function* getFunction(const Identifier& pIdentifier, const CflatArgsVector(TypeUsage)& pParameterTypes);
-      Function* getFunction(const Identifier& pIdentifier, const CflatArgsVector(Value)& pArguments);
+      Function* getFunction(const Identifier& pIdentifier, const ArgsVector<TypeUsage>& pParameterTypes);
+      Function* getFunction(const Identifier& pIdentifier, const ArgsVector<Value>& pArguments);
       Vector<Function*>* getFunctions(const Identifier& pIdentifier);
 
       void setVariable(const TypeUsage& pTypeUsage, const Identifier& pIdentifier, const Value& pValue);
@@ -1345,7 +1346,7 @@ namespace Cflat
 
          Cflat::Value returnValue;
 
-         CflatArgsVector(Value) args;
+         ArgsVector<Value> args;
          initArgumentsForFunctionCall(pFunction, args);
 
          const void* argData[argsCount] = { pArgs... };
@@ -1372,7 +1373,7 @@ namespace Cflat
          Cflat::Value returnValue;
          returnValue.initOnStack(pFunction->mReturnTypeUsage, &mExecutionContext.mStack);
 
-         CflatArgsVector(Value) args;
+         ArgsVector<Value> args;
 
          pFunction->execute(args, &returnValue);
 
@@ -1391,7 +1392,7 @@ namespace Cflat
          Cflat::Value returnValue;
          returnValue.initOnStack(pFunction->mReturnTypeUsage, &mExecutionContext.mStack);
 
-         CflatArgsVector(Value) args;
+         ArgsVector<Value> args;
          initArgumentsForFunctionCall(pFunction, args);
 
          const void* argData[argsCount] = { pArgs... };
@@ -1449,7 +1450,7 @@ namespace Cflat
 #define CflatRegisterFunctionVoid(pEnvironmentPtr, pVoid, pFunctionName) \
    { \
       Cflat::Function* function = (pEnvironmentPtr)->registerFunction(#pFunctionName); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pFunctionName(); \
@@ -1460,7 +1461,7 @@ namespace Cflat
    { \
       Cflat::Function* function = (pEnvironmentPtr)->registerFunction(#pFunctionName); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pFunctionName \
@@ -1476,7 +1477,7 @@ namespace Cflat
       Cflat::Function* function = (pEnvironmentPtr)->registerFunction(#pFunctionName); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pFunctionName \
@@ -1495,7 +1496,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pFunctionName \
@@ -1517,7 +1518,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam3Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pFunctionName \
@@ -1542,7 +1543,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam3Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam4Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pFunctionName \
@@ -1559,7 +1560,7 @@ namespace Cflat
    { \
       Cflat::Function* function = (pEnvironmentPtr)->registerFunction(#pFunctionName); \
       function->mReturnTypeUsage = (pEnvironmentPtr)->getTypeUsage(#pReturnType); CflatValidateTypeUsage(function->mReturnTypeUsage); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -1574,7 +1575,7 @@ namespace Cflat
       Cflat::Function* function = (pEnvironmentPtr)->registerFunction(#pFunctionName); \
       function->mReturnTypeUsage = (pEnvironmentPtr)->getTypeUsage(#pReturnType); CflatValidateTypeUsage(function->mReturnTypeUsage); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -1594,7 +1595,7 @@ namespace Cflat
       function->mReturnTypeUsage = (pEnvironmentPtr)->getTypeUsage(#pReturnType); CflatValidateTypeUsage(function->mReturnTypeUsage); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -1617,7 +1618,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -1643,7 +1644,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam3Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -1672,7 +1673,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam3Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam4Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -1693,7 +1694,7 @@ namespace Cflat
    { \
       Cflat::Function* function = (pEnvironmentPtr)->registerFunction(#pFunctionName); \
       function->mTemplateTypes.push_back((pEnvironmentPtr)->getTypeUsage(#pTemplateType)); CflatValidateTypeUsage(function->mTemplateTypes.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pFunctionName<pTemplateType>(); \
@@ -1705,7 +1706,7 @@ namespace Cflat
       Cflat::Function* function = (pEnvironmentPtr)->registerFunction(#pFunctionName); \
       function->mTemplateTypes.push_back((pEnvironmentPtr)->getTypeUsage(#pTemplateType)); CflatValidateTypeUsage(function->mTemplateTypes.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pFunctionName<pTemplateType> \
@@ -1722,7 +1723,7 @@ namespace Cflat
       function->mTemplateTypes.push_back((pEnvironmentPtr)->getTypeUsage(#pTemplateType)); CflatValidateTypeUsage(function->mTemplateTypes.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pFunctionName<pTemplateType> \
@@ -1742,7 +1743,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pFunctionName<pTemplateType> \
@@ -1765,7 +1766,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam3Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pFunctionName<pTemplateType> \
@@ -1791,7 +1792,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam3Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam4Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pFunctionName<pTemplateType> \
@@ -1809,7 +1810,7 @@ namespace Cflat
       Cflat::Function* function = (pEnvironmentPtr)->registerFunction(#pFunctionName); \
       function->mTemplateTypes.push_back((pEnvironmentPtr)->getTypeUsage(#pTemplateType)); CflatValidateTypeUsage(function->mTemplateTypes.back()); \
       function->mReturnTypeUsage = (pEnvironmentPtr)->getTypeUsage(#pReturnType); CflatValidateTypeUsage(function->mReturnTypeUsage); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -1825,7 +1826,7 @@ namespace Cflat
       function->mTemplateTypes.push_back((pEnvironmentPtr)->getTypeUsage(#pTemplateType)); CflatValidateTypeUsage(function->mTemplateTypes.back()); \
       function->mReturnTypeUsage = (pEnvironmentPtr)->getTypeUsage(#pReturnType); CflatValidateTypeUsage(function->mReturnTypeUsage); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -1846,7 +1847,7 @@ namespace Cflat
       function->mReturnTypeUsage = (pEnvironmentPtr)->getTypeUsage(#pReturnType); CflatValidateTypeUsage(function->mReturnTypeUsage); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -1870,7 +1871,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -1897,7 +1898,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam3Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -1927,7 +1928,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam3Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam4Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -2380,7 +2381,7 @@ namespace Cflat
 #define CflatStructAddStaticMethodVoid(pEnvironmentPtr, pStructType, pVoid, pMethodName) \
    { \
       Cflat::Function* function = static_cast<Cflat::Struct*>((pEnvironmentPtr)->getType(#pStructType))->registerStaticMethod(#pMethodName); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pStructType::pMethodName(); \
@@ -2391,7 +2392,7 @@ namespace Cflat
    { \
       Cflat::Function* function = static_cast<Cflat::Struct*>((pEnvironmentPtr)->getType(#pStructType))->registerStaticMethod(#pMethodName); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pStructType::pMethodName \
@@ -2407,7 +2408,7 @@ namespace Cflat
       Cflat::Function* function = static_cast<Cflat::Struct*>((pEnvironmentPtr)->getType(#pStructType))->registerStaticMethod(#pMethodName); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pStructType::pMethodName \
@@ -2426,7 +2427,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pStructType::pMethodName \
@@ -2448,7 +2449,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam3Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pStructType::pMethodName \
@@ -2473,7 +2474,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam3Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam4Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pStructType::pMethodName \
@@ -2490,7 +2491,7 @@ namespace Cflat
    { \
       Cflat::Function* function = static_cast<Cflat::Struct*>((pEnvironmentPtr)->getType(#pStructType))->registerStaticMethod(#pMethodName); \
       function->mReturnTypeUsage = (pEnvironmentPtr)->getTypeUsage(#pReturnType); CflatValidateTypeUsage(function->mReturnTypeUsage); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -2505,7 +2506,7 @@ namespace Cflat
       Cflat::Function* function = static_cast<Cflat::Struct*>((pEnvironmentPtr)->getType(#pStructType))->registerStaticMethod(#pMethodName); \
       function->mReturnTypeUsage = (pEnvironmentPtr)->getTypeUsage(#pReturnType); CflatValidateTypeUsage(function->mReturnTypeUsage); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -2525,7 +2526,7 @@ namespace Cflat
       function->mReturnTypeUsage = (pEnvironmentPtr)->getTypeUsage(#pReturnType); CflatValidateTypeUsage(function->mReturnTypeUsage); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -2548,7 +2549,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -2574,7 +2575,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam3Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -2603,7 +2604,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam3Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam4Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -2624,7 +2625,7 @@ namespace Cflat
    { \
       Cflat::Function* function = static_cast<Cflat::Struct*>((pEnvironmentPtr)->getType(#pStructType))->registerStaticMethod(#pMethodName); \
       function->mTemplateTypes.push_back((pEnvironmentPtr)->getTypeUsage(#pTemplateType)); CflatValidateTypeUsage(function->mTemplateTypes.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pStructType::pMethodName<pTemplateType>(); \
@@ -2636,7 +2637,7 @@ namespace Cflat
       Cflat::Function* function = static_cast<Cflat::Struct*>((pEnvironmentPtr)->getType(#pStructType))->registerStaticMethod(#pMethodName); \
       function->mTemplateTypes.push_back((pEnvironmentPtr)->getTypeUsage(#pTemplateType)); CflatValidateTypeUsage(function->mTemplateTypes.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pStructType::pMethodName<pTemplateType> \
@@ -2653,7 +2654,7 @@ namespace Cflat
       function->mTemplateTypes.push_back((pEnvironmentPtr)->getTypeUsage(#pTemplateType)); CflatValidateTypeUsage(function->mTemplateTypes.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pStructType::pMethodName<pTemplateType> \
@@ -2673,7 +2674,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pStructType::pMethodName<pTemplateType> \
@@ -2696,7 +2697,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam3Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pStructType::pMethodName<pTemplateType> \
@@ -2722,7 +2723,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam3Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam4Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          pStructType::pMethodName<pTemplateType> \
@@ -2740,7 +2741,7 @@ namespace Cflat
       Cflat::Function* function = static_cast<Cflat::Struct*>((pEnvironmentPtr)->getType(#pStructType))->registerStaticMethod(#pMethodName); \
       function->mTemplateTypes.push_back((pEnvironmentPtr)->getTypeUsage(#pTemplateType)); CflatValidateTypeUsage(function->mTemplateTypes.back()); \
       function->mReturnTypeUsage = (pEnvironmentPtr)->getTypeUsage(#pReturnType); CflatValidateTypeUsage(function->mReturnTypeUsage); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -2756,7 +2757,7 @@ namespace Cflat
       function->mTemplateTypes.push_back((pEnvironmentPtr)->getTypeUsage(#pTemplateType)); CflatValidateTypeUsage(function->mTemplateTypes.back()); \
       function->mReturnTypeUsage = (pEnvironmentPtr)->getTypeUsage(#pReturnType); CflatValidateTypeUsage(function->mReturnTypeUsage); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -2777,7 +2778,7 @@ namespace Cflat
       function->mReturnTypeUsage = (pEnvironmentPtr)->getTypeUsage(#pReturnType); CflatValidateTypeUsage(function->mReturnTypeUsage); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -2801,7 +2802,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -2828,7 +2829,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam3Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -2858,7 +2859,7 @@ namespace Cflat
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam3Type)); CflatValidateTypeUsage(function->mParameters.back()); \
       function->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam4Type)); CflatValidateTypeUsage(function->mParameters.back()); \
-      function->execute = [function](const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+      function->execute = [function](const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          CflatAssert(function->mParameters.size() == pArguments.size()); \
          CflatAssert(pOutReturnValue); \
@@ -3397,24 +3398,24 @@ namespace Cflat
 //  Type definition: Templates
 //
 #define CflatRegisterTemplateStructTypes1(pEnvironmentPtr, pType, pTemplateType) \
-   CflatArgsVector(Cflat::TypeUsage) templateTypes; \
+   Cflat::ArgsVector<Cflat::TypeUsage> templateTypes; \
    templateTypes.push_back((pEnvironmentPtr)->getTypeUsage(#pTemplateType)); CflatValidateTypeUsage(templateTypes.back()); \
    Cflat::Struct* type = (pEnvironmentPtr)->registerTemplate<Cflat::Struct>(#pType, templateTypes); \
    type->mSize = sizeof(pType<pTemplateType>);
 #define CflatRegisterTemplateStructTypes2(pEnvironmentPtr, pType, pTemplateType1, pTemplateType2) \
-   CflatArgsVector(Cflat::TypeUsage) templateTypes; \
+   Cflat::ArgsVector<Cflat::TypeUsage> templateTypes; \
    templateTypes.push_back((pEnvironmentPtr)->getTypeUsage(#pTemplateType1)); CflatValidateTypeUsage(templateTypes.back()); \
    templateTypes.push_back((pEnvironmentPtr)->getTypeUsage(#pTemplateType2)); CflatValidateTypeUsage(templateTypes.back()); \
    Cflat::Struct* type = (pEnvironmentPtr)->registerTemplate<Cflat::Struct>(#pType, templateTypes); \
    type->mSize = sizeof(pType<pTemplateType1, pTemplateType2>);
 
 #define CflatRegisterTemplateClassTypes1(pEnvironmentPtr, pType, pTemplateType) \
-   CflatArgsVector(Cflat::TypeUsage) templateTypes; \
+   Cflat::ArgsVector<Cflat::TypeUsage> templateTypes; \
    templateTypes.push_back((pEnvironmentPtr)->getTypeUsage(#pTemplateType)); CflatValidateTypeUsage(templateTypes.back()); \
    Cflat::Class* type = (pEnvironmentPtr)->registerTemplate<Cflat::Class>(#pType, templateTypes); \
    type->mSize = sizeof(pType<pTemplateType>);
 #define CflatRegisterTemplateClassTypes2(pEnvironmentPtr, pType, pTemplateType1, pTemplateType2) \
-   CflatArgsVector(Cflat::TypeUsage) templateTypes; \
+   Cflat::ArgsVector<Cflat::TypeUsage> templateTypes; \
    templateTypes.push_back((pEnvironmentPtr)->getTypeUsage(#pTemplateType1)); CflatValidateTypeUsage(templateTypes.back()); \
    templateTypes.push_back((pEnvironmentPtr)->getTypeUsage(#pTemplateType2)); CflatValidateTypeUsage(templateTypes.back()); \
    Cflat::Class* type = (pEnvironmentPtr)->registerTemplate<Cflat::Class>(#pType, templateTypes); \
@@ -3445,7 +3446,7 @@ namespace Cflat
       const size_t methodIndex = type->mMethods.size() - 1u; \
       Cflat::Method* method = &type->mMethods.back(); \
       method->execute = [type, methodIndex] \
-         (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+         (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          Cflat::Method* method = &type->mMethods[methodIndex]; \
          new (CflatValueAs(&pThis, pStructType*)) pStructType(); \
@@ -3458,7 +3459,7 @@ namespace Cflat
       Cflat::Method* method = &type->mMethods.back(); \
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->execute = [type, methodIndex] \
-         (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+         (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          Cflat::Method* method = &type->mMethods[methodIndex]; \
          CflatAssert(method->mParameters.size() == pArguments.size()); \
@@ -3477,7 +3478,7 @@ namespace Cflat
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->execute = [type, methodIndex] \
-         (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+         (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          Cflat::Method* method = &type->mMethods[methodIndex]; \
          CflatAssert(method->mParameters.size() == pArguments.size()); \
@@ -3499,7 +3500,7 @@ namespace Cflat
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->execute = [type, methodIndex] \
-         (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+         (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          Cflat::Method* method = &type->mMethods[methodIndex]; \
          CflatAssert(method->mParameters.size() == pArguments.size()); \
@@ -3524,7 +3525,7 @@ namespace Cflat
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam3Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->execute = [type, methodIndex] \
-         (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+         (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          Cflat::Method* method = &type->mMethods[methodIndex]; \
          CflatAssert(method->mParameters.size() == pArguments.size()); \
@@ -3552,7 +3553,7 @@ namespace Cflat
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam3Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam4Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->execute = [type, methodIndex] \
-         (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+         (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          Cflat::Method* method = &type->mMethods[methodIndex]; \
          CflatAssert(method->mParameters.size() == pArguments.size()); \
@@ -3571,7 +3572,7 @@ namespace Cflat
       const size_t methodIndex = type->mMethods.size() - 1u; \
       Cflat::Method* method = &type->mMethods.back(); \
       method->execute = [type, methodIndex] \
-         (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+         (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          Cflat::Method* method = &type->mMethods[methodIndex]; \
          CflatValueAs(&pThis, pStructType*)->~pStructType(); \
@@ -3582,7 +3583,7 @@ namespace Cflat
       const size_t methodIndex = type->mMethods.size() - 1u; \
       Cflat::Method* method = &type->mMethods.back(); \
       method->execute = [type, methodIndex] \
-         (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+         (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          Cflat::Method* method = &type->mMethods[methodIndex]; \
          CflatValueAs(&pThis, pStructType*)->pMethodName(); \
@@ -3595,7 +3596,7 @@ namespace Cflat
       Cflat::Method* method = &type->mMethods.back(); \
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->execute = [type, methodIndex] \
-         (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+         (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          Cflat::Method* method = &type->mMethods[methodIndex]; \
          CflatAssert(method->mParameters.size() == pArguments.size()); \
@@ -3614,7 +3615,7 @@ namespace Cflat
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->execute = [type, methodIndex] \
-         (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+         (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          Cflat::Method* method = &type->mMethods[methodIndex]; \
          CflatAssert(method->mParameters.size() == pArguments.size()); \
@@ -3636,7 +3637,7 @@ namespace Cflat
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->execute = [type, methodIndex] \
-         (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+         (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          Cflat::Method* method = &type->mMethods[methodIndex]; \
          CflatAssert(method->mParameters.size() == pArguments.size()); \
@@ -3661,7 +3662,7 @@ namespace Cflat
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam3Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->execute = [type, methodIndex] \
-         (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+         (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          Cflat::Method* method = &type->mMethods[methodIndex]; \
          CflatAssert(method->mParameters.size() == pArguments.size()); \
@@ -3689,7 +3690,7 @@ namespace Cflat
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam3Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam4Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->execute = [type, methodIndex] \
-         (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+         (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          Cflat::Method* method = &type->mMethods[methodIndex]; \
          CflatAssert(method->mParameters.size() == pArguments.size()); \
@@ -3709,7 +3710,7 @@ namespace Cflat
       Cflat::Method* method = &type->mMethods.back(); \
       method->mReturnTypeUsage = (pEnvironmentPtr)->getTypeUsage(#pReturnType); CflatValidateTypeUsage(method->mReturnTypeUsage); \
       method->execute = [type, methodIndex] \
-         (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+         (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          Cflat::Method* method = &type->mMethods[methodIndex]; \
          CflatAssert(pOutReturnValue); \
@@ -3726,7 +3727,7 @@ namespace Cflat
       method->mReturnTypeUsage = (pEnvironmentPtr)->getTypeUsage(#pReturnType); CflatValidateTypeUsage(method->mReturnTypeUsage); \
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->execute = [type, methodIndex] \
-         (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+         (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          Cflat::Method* method = &type->mMethods[methodIndex]; \
          CflatAssert(pOutReturnValue); \
@@ -3749,7 +3750,7 @@ namespace Cflat
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam0Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->execute = [type, methodIndex] \
-         (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+         (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          Cflat::Method* method = &type->mMethods[methodIndex]; \
          CflatAssert(pOutReturnValue); \
@@ -3775,7 +3776,7 @@ namespace Cflat
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam1Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->execute = [type, methodIndex] \
-         (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+         (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          Cflat::Method* method = &type->mMethods[methodIndex]; \
          CflatAssert(pOutReturnValue); \
@@ -3804,7 +3805,7 @@ namespace Cflat
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam2Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam3Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->execute = [type, methodIndex] \
-         (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+         (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          Cflat::Method* method = &type->mMethods[methodIndex]; \
          CflatAssert(pOutReturnValue); \
@@ -3836,7 +3837,7 @@ namespace Cflat
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam3Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->mParameters.push_back((pEnvironmentPtr)->getTypeUsage(#pParam4Type)); CflatValidateTypeUsage(method->mParameters.back()); \
       method->execute = [type, methodIndex] \
-         (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+         (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
       { \
          Cflat::Method* method = &type->mMethods[methodIndex]; \
          CflatAssert(pOutReturnValue); \

--- a/Cflat.h
+++ b/Cflat.h
@@ -59,6 +59,8 @@
 namespace Cflat
 {
    typedef uint32_t Hash;
+   
+   using LineType = uint32_t;
 
    class Memory
    {
@@ -568,7 +570,7 @@ namespace Cflat
       Identifier mIdentifier;
       TypeUsage mReturnTypeUsage;
       const Program* mProgram{};
-      uint16_t mLine{};
+      LineType mLine{};
       CflatSTLVector(TypeUsage) mTemplateTypes;
       CflatSTLVector(TypeUsage) mParameters;
       CflatSTLVector(Identifier) mParameterIdentifiers;
@@ -806,7 +808,7 @@ namespace Cflat
    };
    
 
-   enum class TokenType
+   enum class TokenType : uint8_t
    {
       Punctuation,
       Number,
@@ -818,11 +820,13 @@ namespace Cflat
 
    struct Token
    {
-      TokenType mType;
       char* mStart;
       size_t mLength;
-      uint16_t mLine;
+      LineType mLine;
+      TokenType mType;
    };
+   
+   //static_assert(sizeof(Token) == 24, "Check Token size");
 
 
    class Tokenizer
@@ -1032,7 +1036,7 @@ namespace Cflat
    {
       const Program* mProgram;
       const Function* mFunction;
-      uint16_t mLine{};
+      LineType mLine{};
 
       CallStackEntry(const Program* pProgram, const Function* pFunction = nullptr);
    };

--- a/Cflat.h
+++ b/Cflat.h
@@ -50,7 +50,6 @@
 #define CflatInvokeDtor(pClassName, pPtr)  (pPtr)->~pClassName()
 
 #define CflatSTLMap(T, U)  std::map<T, U, std::less<T>, Cflat::Memory::STLAllocator<std::pair<const T, U>>>
-#define CflatSTLString  std::basic_string<char, std::char_traits<char>, Cflat::Memory::STLAllocator<char>>
 
 namespace Cflat
 {
@@ -407,6 +406,8 @@ namespace Cflat
    
    template <class T>
    using Deque = std::deque<T, Memory::STLAllocator<T>>;
+   
+   using String = std::basic_string<char, std::char_traits<char>, Memory::STLAllocator<char>>;
    
    
    template<typename T>
@@ -871,7 +872,7 @@ namespace Cflat
    struct Program
    {
       Identifier mIdentifier;
-      CflatSTLString mCode;
+      String mCode;
       Vector<Statement*> mStatements;
 
       ~Program();
@@ -988,8 +989,8 @@ namespace Cflat
    struct Macro
    {
       uint8_t mParametersCount;
-      CflatSTLString mName;
-      Vector<CflatSTLString> mBody;
+      String mName;
+      Vector<String> mBody;
    };
 
    enum class ContextType
@@ -1009,7 +1010,7 @@ namespace Cflat
       Vector<Namespace*> mNamespaceStack;
       Vector<UsingDirective> mUsingDirectives;
       Vector<TypeAlias> mTypeAliases;
-      CflatSTLString mStringBuffer;
+      String mStringBuffer;
       InstancesHolder mLocalInstancesHolder;
       EnvironmentStack mStack;
 
@@ -1019,7 +1020,7 @@ namespace Cflat
 
    struct ParsingContext : Context
    {
-      CflatSTLString mPreprocessedCode;
+      String mPreprocessedCode;
       Vector<Token> mTokens;
       size_t mTokenIndex{};
 
@@ -1132,7 +1133,7 @@ namespace Cflat
 
       ParsingContext mTypesParsingContext;
       ExecutionContext mExecutionContext;
-      CflatSTLString mErrorMessage;
+      String mErrorMessage;
 
       Namespace mGlobalNamespace;
 

--- a/Cflat.h
+++ b/Cflat.h
@@ -64,7 +64,7 @@ namespace Cflat
       (pBitMask &= ~(static_cast<int>(pFlag)));
    }
    
-   typedef uint32_t Hash;
+   using Hash = uint32_t;
    
    using LineType = uint32_t;
 
@@ -78,16 +78,16 @@ namespace Cflat
       class STLAllocator
       {
       public:
-         typedef T value_type;
-         typedef T* pointer;
-         typedef const T* const_pointer;
-         typedef T& reference;
-         typedef const T& const_reference;
-         typedef std::size_t size_type;
-         typedef std::ptrdiff_t difference_type;
+         using value_type = T;
+         using pointer = T*;
+         using const_pointer = const T*;
+         using reference = T&;
+         using const_reference = const T&;
+         using size_type = std::size_t;
+         using difference_type = std::ptrdiff_t;
 
          template<typename U>
-         struct rebind { typedef STLAllocator<U> other; };
+         struct rebind { using other = STLAllocator<U>; };
 
          pointer address(reference pRef) const { return &pRef; }
          const_pointer address(const_reference pRef) const { return &pRef; }
@@ -122,8 +122,8 @@ namespace Cflat
       class StackVector
       {
       public:
-         typedef T* iterator;
-         typedef const T* const_iterator;
+         using iterator = T*;
+         using const_iterator = const T*;
 
       private:
          iterator mFirst;
@@ -357,7 +357,7 @@ namespace Cflat
          char mMemory[Size];
          char* mPointer;
 
-         typedef CflatSTLMap(Hash, const char*) Registry;
+         using Registry = CflatSTLMap(Hash, const char*);
          Registry mRegistry;
 
          StringsRegistry()
@@ -453,7 +453,7 @@ namespace Cflat
 
    struct Identifier
    {
-      typedef Memory::StringsRegistry<kIdentifierStringsPoolSize> NamesRegistry;
+      using NamesRegistry = Memory::StringsRegistry<kIdentifierStringsPoolSize>;
       static NamesRegistry* smNames;
 
       static NamesRegistry* getNamesRegistry();
@@ -550,7 +550,7 @@ namespace Cflat
       Stack // to be allocated on the stack
    };
 
-   typedef Memory::StackPool<kEnvironmentStackSize> EnvironmentStack;
+   using EnvironmentStack = Memory::StackPool<kEnvironmentStackSize>;
 
    struct Value
    {
@@ -632,10 +632,10 @@ namespace Cflat
    class TypesHolder
    {
    private:
-      typedef CflatSTLMap(Hash, Type*) TypesRegistry;
+      using TypesRegistry = CflatSTLMap(Hash, Type*);
       TypesRegistry mTypes;
 
-      typedef CflatSTLMap(Hash, TypeAlias) TypeAliasesRegistry;
+      using TypeAliasesRegistry = CflatSTLMap(Hash, TypeAlias);
       TypeAliasesRegistry mTypeAliases;
 
    public:
@@ -697,7 +697,7 @@ namespace Cflat
    class FunctionsHolder
    {
    private:
-      typedef CflatSTLMap(Hash, Vector<Function*>) FunctionsRegistry;
+      using FunctionsRegistry = CflatSTLMap(Hash, Vector<Function*>);
       FunctionsRegistry mFunctions;
 
    public:
@@ -899,7 +899,7 @@ namespace Cflat
       Namespace* mParent;
       Environment* mEnvironment;
 
-      typedef CflatSTLMap(Hash, Namespace*) NamespacesRegistry;
+      using NamespacesRegistry = CflatSTLMap(Hash, Namespace*) ;
       NamespacesRegistry mNamespaces;
 
       TypesHolder mTypesHolder;
@@ -1063,7 +1063,7 @@ namespace Cflat
       CallStackEntry(const Program* pProgram, const Function* pFunction = nullptr);
    };
 
-   typedef Vector<CallStackEntry> CallStack;
+   using CallStack = Vector<CallStackEntry>;
 
    enum class JumpStatement : uint8_t
    {
@@ -1133,13 +1133,13 @@ namespace Cflat
 
       Vector<Macro> mMacros;
 
-      typedef CflatSTLMap(Hash, Program*) ProgramsRegistry;
+      using ProgramsRegistry = CflatSTLMap(Hash, Program*);
       ProgramsRegistry mPrograms;
 
-      typedef Memory::StringsRegistry<kLiteralStringsPoolSize> LiteralStringsPool;
+      using LiteralStringsPool = Memory::StringsRegistry<kLiteralStringsPoolSize>;
       LiteralStringsPool mLiteralStringsPool;
 
-      typedef CflatSTLMap(uint64_t, Value) StaticValuesRegistry;
+      using StaticValuesRegistry = CflatSTLMap(uint64_t, Value);
       StaticValuesRegistry mStaticValues;
 
       ParsingContext mTypesParsingContext;
@@ -1160,7 +1160,7 @@ namespace Cflat
       TypeUsage mTypeUsageCString;
       TypeUsage mTypeUsageVoidPtr;
 
-      typedef void (*ExecutionHook)(Environment* pEnvironment, const CallStack& pCallStack);
+      using ExecutionHook = void (*)(Environment* pEnvironment, const CallStack& pCallStack);
       ExecutionHook mExecutionHook{};
 
       void registerBuiltInTypes();

--- a/Cflat.h
+++ b/Cflat.h
@@ -50,7 +50,6 @@
 #define CflatInvokeDtor(pClassName, pPtr)  (pPtr)->~pClassName()
 
 #define CflatSTLVector(T)  std::vector<T, Cflat::Memory::STLAllocator<T>>
-#define CflatSTLDeque(T)   std::deque<T, Cflat::Memory::STLAllocator<T>>
 #define CflatSTLMap(T, U)  std::map<T, U, std::less<T>, Cflat::Memory::STLAllocator<std::pair<const T, U>>>
 #define CflatSTLString  std::basic_string<char, std::char_traits<char>, Cflat::Memory::STLAllocator<char>>
 
@@ -404,6 +403,10 @@ namespace Cflat
    {
       return pArgsVector == pSTLVector;
    }
+   
+   
+   template <class T>
+   using Deque = std::deque<T, Memory::STLAllocator<T>>;
 
 
    enum class TypeCategory : uint8_t
@@ -698,7 +701,7 @@ namespace Cflat
    class InstancesHolder
    {
    private:
-      CflatSTLDeque(Instance) mInstances;
+      Deque<Instance> mInstances;
 
    public:
       ~InstancesHolder();

--- a/Cflat.h
+++ b/Cflat.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <cstdint>
+#include <deque>
 #include <functional>
 #include <vector>
 #include <map>
@@ -49,6 +50,7 @@
 #define CflatInvokeDtor(pClassName, pPtr)  (pPtr)->~pClassName()
 
 #define CflatSTLVector(T)  std::vector<T, Cflat::Memory::STLAllocator<T>>
+#define CflatSTLDeque(T)   std::deque<T, Cflat::Memory::STLAllocator<T>>
 #define CflatSTLMap(T, U)  std::map<T, U, std::less<T>, Cflat::Memory::STLAllocator<std::pair<const T, U>>>
 #define CflatSTLString  std::basic_string<char, std::char_traits<char>, Cflat::Memory::STLAllocator<char>>
 
@@ -694,11 +696,9 @@ namespace Cflat
    class InstancesHolder
    {
    private:
-      CflatSTLVector(Instance) mInstances;
-      size_t mMaxInstances;
+      CflatSTLDeque(Instance) mInstances;
 
    public:
-      InstancesHolder(size_t pMaxInstances);
       ~InstancesHolder();
 
       void setVariable(const TypeUsage& pTypeUsage, const Identifier& pIdentifier, const Value& pValue);

--- a/Cflat.h
+++ b/Cflat.h
@@ -433,7 +433,7 @@ namespace Cflat
       static NamesRegistry* getNamesRegistry();
       static void releaseNamesRegistry();
 
-      Hash mHash;
+      Hash mHash{};
       const char* mName;
 
       Identifier();
@@ -449,9 +449,9 @@ namespace Cflat
    struct Type
    {
       Namespace* mNamespace;
-      Type* mParent;
+      Type* mParent{};
       Identifier mIdentifier;
-      size_t mSize;
+      size_t mSize{};
       TypeCategory mCategory;
 
       virtual ~Type();
@@ -472,12 +472,10 @@ namespace Cflat
    {
       static const CflatArgsVector(TypeUsage) kEmptyList;
 
-      Type* mType;
-      uint16_t mArraySize;
-      uint8_t mPointerLevel;
-      uint8_t mFlags;
-
-      TypeUsage();
+      Type* mType{};
+      uint16_t mArraySize{1u};
+      uint8_t mPointerLevel{};
+      uint8_t mFlags{};
 
       size_t getSize() const;
 
@@ -496,7 +494,7 @@ namespace Cflat
    {
      Identifier mIdentifier;
      TypeUsage mTypeUsage;
-     uint32_t mScopeLevel;
+     uint32_t mScopeLevel{};
 
      TypeAlias();
      TypeAlias(const Identifier& pIdentifier, const TypeUsage& pTypeUsage);
@@ -506,7 +504,7 @@ namespace Cflat
    {
       Identifier mIdentifier;
       TypeUsage mTypeUsage;
-      uint16_t mOffset;
+      uint16_t mOffset{};
 
       Member(const Identifier& pIdentifier);
    };
@@ -535,8 +533,8 @@ namespace Cflat
       TypeUsage mTypeUsage;
       ValueBufferType mValueBufferType;
       ValueInitializationHint mValueInitializationHint;
-      char* mValueBuffer;
-      EnvironmentStack* mStack;
+      char* mValueBuffer{};
+      EnvironmentStack* mStack{};
 
       Value();
       Value(const Value& pOther);
@@ -597,7 +595,7 @@ namespace Cflat
    {
       TypeUsage mTypeUsage;
       Identifier mIdentifier;
-      uint32_t mScopeLevel;
+      uint32_t mScopeLevel{};
       Value mValue;
 
       Instance();

--- a/Cflat.h
+++ b/Cflat.h
@@ -42,10 +42,6 @@
 #define CflatMalloc  Cflat::Memory::malloc
 #define CflatFree  Cflat::Memory::free
 
-#define CflatHasFlag(pBitMask, pFlag)  ((pBitMask & (int)pFlag) > 0)
-#define CflatSetFlag(pBitMask, pFlag)  (pBitMask |= (int)pFlag)
-#define CflatResetFlag(pBitMask, pFlag)  (pBitMask &= ~((int)pFlag))
-
 #define CflatInvokeCtor(pClassName, pPtr)  new (pPtr) pClassName
 #define CflatInvokeDtor(pClassName, pPtr)  (pPtr)->~pClassName()
 
@@ -53,6 +49,21 @@
 
 namespace Cflat
 {
+   template <class BitMaskType, class FlagType>
+   inline bool has_flag(const BitMaskType pBitMask, const FlagType pFlag) {
+      return ((pBitMask & static_cast<int>(pFlag)) > 0);
+   }
+   
+   template <class BitMaskType, class FlagType>
+   inline void set_flag(BitMaskType& pBitMask, const FlagType pFlag) {
+      (pBitMask |= static_cast<int>(pFlag));
+   }
+   
+   template <class BitMaskType, class FlagType>
+   inline void reset_flag(BitMaskType& pBitMask, const FlagType pFlag) {
+      (pBitMask &= ~(static_cast<int>(pFlag)));
+   }
+   
    typedef uint32_t Hash;
    
    using LineType = uint32_t;
@@ -1973,7 +1984,7 @@ namespace Cflat
       const pType enumValueInstance = pValueName; \
       Cflat::Value enumValue; \
       enumValue.mTypeUsage.mType = (pOwnerPtr)->getType(#pType); \
-      CflatSetFlag(enumValue.mTypeUsage.mFlags, Cflat::TypeUsageFlags::Const); \
+      set_flag(enumValue.mTypeUsage.mFlags, Cflat::TypeUsageFlags::Const); \
       enumValue.initOnHeap(enumValue.mTypeUsage); \
       enumValue.set(&enumValueInstance); \
       const Cflat::Identifier identifier(#pValueName); \
@@ -1984,7 +1995,7 @@ namespace Cflat
       const pParentType::pType enumValueInstance = pParentType::pValueName; \
       Cflat::TypeUsage enumTypeUsage; \
       enumTypeUsage.mType = type; \
-      CflatSetFlag(enumTypeUsage.mFlags, Cflat::TypeUsageFlags::Const); \
+      set_flag(enumTypeUsage.mFlags, Cflat::TypeUsageFlags::Const); \
       const Cflat::Identifier identifier(#pValueName); \
       Cflat::Struct* parentType = static_cast<Cflat::Struct*>((pOwnerPtr)->getType(#pParentType)); \
       Cflat::Instance* instance = parentType->mInstancesHolder.registerInstance(enumTypeUsage, identifier); \
@@ -2005,7 +2016,7 @@ namespace Cflat
       const pType enumValueInstance = pType::pValueName; \
       Cflat::Value enumValue; \
       enumValue.mTypeUsage.mType = (pOwnerPtr)->getType(#pType); \
-      CflatSetFlag(enumValue.mTypeUsage.mFlags, Cflat::TypeUsageFlags::Const); \
+      set_flag(enumValue.mTypeUsage.mFlags, Cflat::TypeUsageFlags::Const); \
       enumValue.initOnHeap(enumValue.mTypeUsage); \
       enumValue.set(&enumValueInstance); \
       const Cflat::Identifier identifier(#pValueName); \

--- a/Cflat.h
+++ b/Cflat.h
@@ -564,17 +564,17 @@ namespace Cflat
 
    struct Function
    {
-      Namespace* mNamespace;
+      Namespace* mNamespace{};
       Identifier mIdentifier;
       TypeUsage mReturnTypeUsage;
-      const Program* mProgram;
-      uint16_t mLine;
+      const Program* mProgram{};
+      uint16_t mLine{};
       CflatSTLVector(TypeUsage) mTemplateTypes;
       CflatSTLVector(TypeUsage) mParameters;
       CflatSTLVector(Identifier) mParameterIdentifiers;
       CflatSTLVector(UsingDirective) mUsingDirectives;
 
-      std::function<void(const CflatArgsVector(Value)& pArgs, Value* pOutReturnValue)> execute;
+      std::function<void(const CflatArgsVector(Value)& pArgs, Value* pOutReturnValue)> execute{};
 
       Function(const Identifier& pIdentifier);
       ~Function();
@@ -1007,7 +1007,7 @@ namespace Cflat
    {
       CflatSTLString mPreprocessedCode;
       CflatSTLVector(Token) mTokens;
-      size_t mTokenIndex;
+      size_t mTokenIndex{};
 
       struct RegisteredInstance
       {
@@ -1032,7 +1032,7 @@ namespace Cflat
    {
       const Program* mProgram;
       const Function* mFunction;
-      uint16_t mLine;
+      uint16_t mLine{};
 
       CallStackEntry(const Program* pProgram, const Function* pFunction = nullptr);
    };
@@ -1135,7 +1135,7 @@ namespace Cflat
       TypeUsage mTypeUsageVoidPtr;
 
       typedef void (*ExecutionHook)(Environment* pEnvironment, const CallStack& pCallStack);
-      ExecutionHook mExecutionHook;
+      ExecutionHook mExecutionHook{};
 
       void registerBuiltInTypes();
 

--- a/Cflat.h
+++ b/Cflat.h
@@ -993,7 +993,7 @@ namespace Cflat
       Vector<String> mBody;
    };
 
-   enum class ContextType
+   enum class ContextType : uint8_t
    {
       Parsing,
       Execution
@@ -1035,7 +1035,7 @@ namespace Cflat
       ParsingContext(Namespace* pGlobalNamespace);
    };
 
-   enum class CastType
+   enum class CastType : uint8_t
    {
       CStyle,
       Static,
@@ -1054,7 +1054,7 @@ namespace Cflat
 
    typedef Vector<CallStackEntry> CallStack;
 
-   enum class JumpStatement : uint16_t
+   enum class JumpStatement : uint8_t
    {
       None,
       Break,

--- a/CflatConfig.h
+++ b/CflatConfig.h
@@ -50,13 +50,6 @@ namespace Cflat
   // Size in bytes for the environment stack
   static const size_t kEnvironmentStackSize = 8192u;
 
-  // Maximum number of global variables/constants per namespace
-  static const size_t kMaxGlobalInstancesPerNamespace = 32u;
-  // Maximum number of local variables/constants in an execution context
-  static const size_t kMaxLocalInstances = 32u;
-  // Maximum number of static members in a struct or class
-  static const size_t kMaxStaticMembers = 8u;
-
   // Size in bytes for local string buffers
   static const size_t kDefaultLocalStringBufferSize = 256u;
 }

--- a/CflatHelper.h
+++ b/CflatHelper.h
@@ -253,8 +253,8 @@ namespace Cflat
 #define CflatRegisterSTLMapCustom(pEnvironmentPtr, pContainer, pPair, K, V) \
    { \
       CflatRegisterTemplateClassTypes2(pEnvironmentPtr, pContainer, K, V); \
-      typedef pContainer<K, V> MapType; \
-      typedef pPair<const K, V> PairType; \
+      using MapType = pContainer<K, V>; \
+      using PairType = pPair<const K, V>; \
       CflatClassAddConstructor(pEnvironmentPtr, MapType); \
       CflatClassAddMethodReturn(pEnvironmentPtr, MapType, bool, empty); \
       CflatClassAddMethodReturn(pEnvironmentPtr, MapType, size_t, size); \

--- a/CflatHelper.h
+++ b/CflatHelper.h
@@ -116,7 +116,7 @@ namespace Cflat
             parameter.mFlags = (uint8_t)Cflat::TypeUsageFlags::Const | (uint8_t)Cflat::TypeUsageFlags::Reference; \
             method.mParameters.push_back(parameter); \
             method.execute = [iteratorType, methodIndex] \
-               (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+               (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
             { \
                Cflat::Method* method = &iteratorType->mMethods[methodIndex]; \
                CflatAssert(pOutReturnValue); \
@@ -135,7 +135,7 @@ namespace Cflat
             parameter.mFlags = (uint8_t)Cflat::TypeUsageFlags::Const | (uint8_t)Cflat::TypeUsageFlags::Reference; \
             method.mParameters.push_back(parameter); \
             method.execute = [iteratorType, methodIndex] \
-               (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+               (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
             { \
                Cflat::Method* method = &iteratorType->mMethods[methodIndex]; \
                CflatAssert(pOutReturnValue); \
@@ -150,7 +150,7 @@ namespace Cflat
             Cflat::Method method("operator*"); \
             method.mReturnTypeUsage = (pEnvironmentPtr)->getTypeUsage(#T"&"); CflatValidateTypeUsage(method.mReturnTypeUsage); \
             method.execute = [iteratorType, methodIndex] \
-               (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+               (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
             { \
                Cflat::Method* method = &iteratorType->mMethods[methodIndex]; \
                CflatAssert(pOutReturnValue); \
@@ -166,7 +166,7 @@ namespace Cflat
             method.mReturnTypeUsage.mType = iteratorType; \
             method.mReturnTypeUsage.mFlags = (uint8_t)Cflat::TypeUsageFlags::Reference; \
             method.execute = [iteratorType, methodIndex] \
-               (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+               (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
             { \
                Cflat::Method* method = &iteratorType->mMethods[methodIndex]; \
                CflatAssert(pOutReturnValue); \
@@ -182,7 +182,7 @@ namespace Cflat
             method.mReturnTypeUsage.mType = iteratorType; \
             method.mParameters.push_back((pEnvironmentPtr)->getTypeUsage("int")); \
             method.execute = [iteratorType, methodIndex] \
-               (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+               (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
             { \
                Cflat::Method* method = &iteratorType->mMethods[methodIndex]; \
                CflatAssert(pOutReturnValue); \
@@ -201,7 +201,7 @@ namespace Cflat
          Cflat::Method method("begin"); \
          method.mReturnTypeUsage.mType = iteratorType; \
          method.execute = [type, methodIndex] \
-            (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+            (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
          { \
             Cflat::Method* method = &type->mMethods[methodIndex]; \
             CflatAssert(pOutReturnValue); \
@@ -216,7 +216,7 @@ namespace Cflat
          Cflat::Method method("end"); \
          method.mReturnTypeUsage.mType = iteratorType; \
          method.execute = [type, methodIndex] \
-            (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+            (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
          { \
             Cflat::Method* method = &type->mMethods[methodIndex]; \
             CflatAssert(pOutReturnValue); \
@@ -234,7 +234,7 @@ namespace Cflat
          parameter.mType = iteratorType; \
          method.mParameters.push_back(parameter); \
          method.execute = [type, methodIndex] \
-            (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+            (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
          { \
             Cflat::Method* method = &type->mMethods[methodIndex]; \
             CflatAssert(pOutReturnValue); \
@@ -260,7 +260,7 @@ namespace Cflat
       CflatClassAddMethodReturn(pEnvironmentPtr, MapType, size_t, size); \
       CflatClassAddMethodVoid(pEnvironmentPtr, MapType, void, clear); \
       CflatClassAddMethodReturnParams1(pEnvironmentPtr, MapType, V&, operator[], const K&); \
-      CflatArgsVector(Cflat::TypeUsage) mapTemplateTypes; \
+      Cflat::ArgsVector<Cflat::TypeUsage> mapTemplateTypes; \
       mapTemplateTypes.push_back((pEnvironmentPtr)->getTypeUsage(#K)); CflatValidateTypeUsage(mapTemplateTypes.back()); \
       mapTemplateTypes.push_back((pEnvironmentPtr)->getTypeUsage(#V)); CflatValidateTypeUsage(mapTemplateTypes.back()); \
       Cflat::Class* pairType = nullptr; \
@@ -293,7 +293,7 @@ namespace Cflat
             parameter.mFlags = (uint8_t)Cflat::TypeUsageFlags::Const | (uint8_t)Cflat::TypeUsageFlags::Reference; \
             method.mParameters.push_back(parameter); \
             method.execute = [iteratorType, methodIndex] \
-               (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+               (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
             { \
                Cflat::Method* method = &iteratorType->mMethods[methodIndex]; \
                CflatAssert(pOutReturnValue); \
@@ -312,7 +312,7 @@ namespace Cflat
             parameter.mFlags = (uint8_t)Cflat::TypeUsageFlags::Const | (uint8_t)Cflat::TypeUsageFlags::Reference; \
             method.mParameters.push_back(parameter); \
             method.execute = [iteratorType, methodIndex] \
-               (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+               (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
             { \
                Cflat::Method* method = &iteratorType->mMethods[methodIndex]; \
                CflatAssert(pOutReturnValue); \
@@ -328,7 +328,7 @@ namespace Cflat
             method.mReturnTypeUsage.mType = pairType; \
             method.mReturnTypeUsage.mFlags = (uint8_t)Cflat::TypeUsageFlags::Const | (uint8_t)Cflat::TypeUsageFlags::Reference; \
             method.execute = [iteratorType, methodIndex] \
-               (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+               (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
             { \
                Cflat::Method* method = &iteratorType->mMethods[methodIndex]; \
                CflatAssert(pOutReturnValue); \
@@ -344,7 +344,7 @@ namespace Cflat
             method.mReturnTypeUsage.mType = iteratorType; \
             method.mReturnTypeUsage.mFlags = (uint8_t)Cflat::TypeUsageFlags::Reference; \
             method.execute = [iteratorType, methodIndex] \
-               (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+               (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
             { \
                Cflat::Method* method = &iteratorType->mMethods[methodIndex]; \
                CflatAssert(pOutReturnValue); \
@@ -362,7 +362,7 @@ namespace Cflat
          method.mParameters.push_back(mapTemplateTypes[0]); \
          method.mParameters.back().mFlags = (uint8_t)Cflat::TypeUsageFlags::Const | (uint8_t)Cflat::TypeUsageFlags::Reference; \
          method.execute = [type, methodIndex] \
-            (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+            (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
          { \
             Cflat::Method* method = &type->mMethods[methodIndex]; \
             CflatAssert(pOutReturnValue); \
@@ -380,7 +380,7 @@ namespace Cflat
          Cflat::Method method("begin"); \
          method.mReturnTypeUsage.mType = iteratorType; \
          method.execute = [type, methodIndex] \
-            (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+            (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
          { \
             Cflat::Method* method = &type->mMethods[methodIndex]; \
             CflatAssert(pOutReturnValue); \
@@ -395,7 +395,7 @@ namespace Cflat
          Cflat::Method method("end"); \
          method.mReturnTypeUsage.mType = iteratorType; \
          method.execute = [type, methodIndex] \
-            (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+            (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
          { \
             Cflat::Method* method = &type->mMethods[methodIndex]; \
             CflatAssert(pOutReturnValue); \
@@ -413,7 +413,7 @@ namespace Cflat
          parameter.mType = iteratorType; \
          method.mParameters.push_back(parameter); \
          method.execute = [type, methodIndex] \
-            (const Cflat::Value& pThis, const CflatArgsVector(Cflat::Value)& pArguments, Cflat::Value* pOutReturnValue) \
+            (const Cflat::Value& pThis, const Cflat::ArgsVector<Cflat::Value>& pArguments, Cflat::Value* pOutReturnValue) \
          { \
             Cflat::Method* method = &type->mMethods[methodIndex]; \
             CflatAssert(pOutReturnValue); \

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1975,7 +1975,7 @@ TEST(Cflat, FunctionDeclarationNoParams)
 
    int& var = CflatValueAs(env.getVariable("var"), int);
 
-   CflatArgsVector(Cflat::Value) args;
+   Cflat::ArgsVector<Cflat::Value> args;
 
    Cflat::Function* func = env.getFunction("func");
    EXPECT_TRUE(func);
@@ -2006,7 +2006,7 @@ TEST(Cflat, FunctionDeclarationWithParam)
    arg.initOnHeap(argTypeUsage);
    arg.set(&argValue);
 
-   CflatArgsVector(Cflat::Value) args;
+   Cflat::ArgsVector<Cflat::Value> args;
    args.push_back(arg);
 
    Cflat::Function* func = env.getFunction("func");


### PR DESCRIPTION
Minor fix to include `cmath` header for `fabs` and using `std::fabs`. Necessary to compile with Apple clang.