### PR TITLE
Make CflatRegisterSTLVectorCustom work with EASTL vectors

### DIFF
--- a/CflatHelper.h
+++ b/CflatHelper.h
@@ -157,7 +157,7 @@ namespace Cflat
                Cflat::Method* method = &iteratorType->mMethods[methodIndex]; \
                CflatAssert(pOutReturnValue); \
                CflatAssert(pOutReturnValue->mTypeUsage.compatibleWith(method->mReturnTypeUsage)); \
-               T& result = CflatValueAs(&pThis, pContainer<T>::iterator*)->operator*(); \
+               T& result = **CflatValueAs(&pThis, pContainer<T>::iterator*); \
                pOutReturnValue->set(&result); \
             }; \
             iteratorType->mMethods.push_back(method); \
@@ -173,7 +173,7 @@ namespace Cflat
                Cflat::Method* method = &iteratorType->mMethods[methodIndex]; \
                CflatAssert(pOutReturnValue); \
                CflatAssert(pOutReturnValue->mTypeUsage.compatibleWith(method->mReturnTypeUsage)); \
-               pContainer<T>::iterator& result = CflatValueAs(&pThis, pContainer<T>::iterator*)->operator++(); \
+               pContainer<T>::iterator& result = ++(*CflatValueAs(&pThis, pContainer<T>::iterator*)); \
                pOutReturnValue->set(&result); \
             }; \
             iteratorType->mMethods.push_back(method); \
@@ -189,7 +189,7 @@ namespace Cflat
                Cflat::Method* method = &iteratorType->mMethods[methodIndex]; \
                CflatAssert(pOutReturnValue); \
                CflatAssert(pOutReturnValue->mTypeUsage.compatibleWith(method->mReturnTypeUsage)); \
-               pContainer<T>::iterator result = CflatValueAs(&pThis, pContainer<T>::iterator*)->operator+ \
+               pContainer<T>::iterator result = *CflatValueAs(&pThis, pContainer<T>::iterator*) + \
                ( \
                   CflatValueAs(&pArguments[0], int) \
                ); \


### PR DESCRIPTION
vector iterators in EASTL are plain pointers so operator* and friends can't be used. The C++ standard might even allow that (iterators are modeled after pointers after all) but I haven't checked.
I also haven't checked that this actually works... but it compiles so I'm sure it'll be fine.