### PR TITLE
Added more simple escape chars for most C usecases

### DIFF
--- a/Cflat.cpp
+++ b/Cflat.cpp
@@ -3648,19 +3648,24 @@ Expression* Environment::parseExpressionLiteralString(ParsingContext& pContext, 
             {
                pContext.mStringBuffer.push_back('\n');
             }
-            else if(escapeChar == 't'){
+            else if(escapeChar == 't')
+            {
                pContext.mStringBuffer.push_back('\t');
             }
-            else if(escapeChar == 'r'){
+            else if(escapeChar == 'r')
+            {
                pContext.mStringBuffer.push_back('\r');
             }
-            else if(escapeChar == '"'){
+            else if(escapeChar == '"')
+            {
                pContext.mStringBuffer.push_back('\"');
             }
-            else if(escapeChar == '\''){
+            else if(escapeChar == '\'')
+            {
                pContext.mStringBuffer.push_back('\'');
             }
-            else if(escapeChar == '0'){
+            else if(escapeChar == '0')
+            {
                pContext.mStringBuffer.push_back('\0');
             }
             else

--- a/Cflat.cpp
+++ b/Cflat.cpp
@@ -3632,6 +3632,21 @@ Expression* Environment::parseExpressionLiteralString(ParsingContext& pContext)
             {
                pContext.mStringBuffer.push_back('\n');
             }
+            else if(escapeChar == 't'){
+               pContext.mStringBuffer.push_back('\t');
+            }
+            else if(escapeChar == 'r'){
+               pContext.mStringBuffer.push_back('\r');
+            }
+            else if(escapeChar == '"'){
+               pContext.mStringBuffer.push_back('\"');
+            }
+            else if(escapeChar == '\''){
+               pContext.mStringBuffer.push_back('\'');
+            }
+            else if(escapeChar == '0'){
+               pContext.mStringBuffer.push_back('\0');
+            }
             else
             {
                pContext.mStringBuffer.push_back('\\');

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -392,6 +392,33 @@ TEST(Cflat, MultilineStringLiteral)
   const char* str = CflatValueAs(env.getVariable("str"), const char*);
   EXPECT_EQ(strcmp(str, "Hello world!"), 0);
 }
+TEST(Cflat, StringLiteralWithEscapeChars)
+{
+  Cflat::Environment env;
+
+  const char* code =
+    "const char* str = \"newlines Wow !\\n\";\n"
+    "const char* str1 = \"\\tmuch tabs\";\n"
+    "const char* str2 = \"such return\\r\";\n"
+    "const char* str3 = \"doppelt quotes\\\"\";\n"
+    "const char* str4 = \"quote me one more time\\'\";\n"
+    "const char* str5 = \"Hell\\0o people\";\n";
+
+  EXPECT_TRUE(env.load("test", code));
+
+  const char* str = CflatValueAs(env.getVariable("str"), const char*);
+  EXPECT_EQ(strcmp(str, "newlines Wow !\n"), 0);
+  str = CflatValueAs(env.getVariable("str1"), const char*);
+  EXPECT_EQ(strcmp(str, "\tmuch tabs"), 0);
+  str = CflatValueAs(env.getVariable("str2"), const char*);
+  EXPECT_EQ(strcmp(str, "such return\r"), 0);
+  str = CflatValueAs(env.getVariable("str3"), const char*);
+  EXPECT_EQ(strcmp(str, "doppelt quotes\""), 0);
+  str = CflatValueAs(env.getVariable("str4"), const char*);
+  EXPECT_EQ(strcmp(str, "quote me one more time\'"), 0);
+  str = CflatValueAs(env.getVariable("str5"), const char*);
+  EXPECT_EQ(strcmp(str, "Hell"), 0);
+}
 
 TEST(Cflat, WideStrings)
 {


### PR DESCRIPTION
- I needed to support `\"` in my const char* string literals. The behavior was weird with my strings since we just replace anything other then the supported chars with `\\`. For now I simply added the most common/simple of the escape chars. Maybe we should determine if we will support [all](https://en.cppreference.com/w/cpp/language/escape) or what would be the acceptable subset to support.

- I think it would maybe be pertinent to send an error or a general message to indicate when one  escape char isn't supported ? Maybe it doesn't matter.

- I added a test case for the escape chars. I don't know what would be the acceptable granularity for you(i.e. do we test everything that we support ?). Regarding the tests.cpp, their isn't a main function, so I guess you add this file to another in your other project to run the tests ? It doesn't really matter but maybe we could add a `test_main.cpp` file to the tests folder so , users that are exclusive to Cflat could just add that file to their compilation setup without adding the main function manually all the time in tests.cpp. Here is what I am thinking:
```c++
// test_main.cpp
#include "tests.cpp"
int main(int argc, char **argv) {
    testing::InitGoogleTest(&argc, argv);
    return RUN_ALL_TESTS();
}
```
Sorry for the wall of text. Good day, thanks for this cool and useful project ! 